### PR TITLE
feat: Add sms permission request

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":ui"))
     implementation(project(":features:app-list"))
     implementation(project(":features:homepage-action"))
+    implementation(project(":features:permissions"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:name="android.hardware.telephony"
         android:required="false" />
     <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
 
     <application
         android:name=".SimpleLauncherApplication"

--- a/app/src/main/java/com/duchastel/simon/simplelauncher/MainActivity.kt
+++ b/app/src/main/java/com/duchastel/simon/simplelauncher/MainActivity.kt
@@ -1,25 +1,26 @@
 package com.duchastel.simon.simplelauncher
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import com.duchastel.simon.simplelauncher.features.applist.ui.AppListScreen
-import com.duchastel.simon.simplelauncher.features.homepageaction.ui.HomepageActionScreen
+import com.duchastel.simon.simplelauncher.features.permissions.data.Permission
+import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepository
 import com.duchastel.simon.simplelauncher.ui.theme.SimpleLauncherTheme
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitContent
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/di/AppListModule.kt
+++ b/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/di/AppListModule.kt
@@ -14,12 +14,12 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.components.ActivityComponent
 import dagger.multibindings.IntoSet
 
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityComponent::class)
 abstract class AppListModule {
     @Binds
     abstract fun bindAppRepository(impl: AppRepositoryImpl): AppRepository

--- a/features/homepage-action/src/main/java/com/duchastel/simon/simplelauncher/features/homepageaction/di/HomepageActionModule.kt
+++ b/features/homepage-action/src/main/java/com/duchastel/simon/simplelauncher/features/homepageaction/di/HomepageActionModule.kt
@@ -11,11 +11,11 @@ import com.slack.circuit.runtime.ui.Ui
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.components.ActivityComponent
 import dagger.multibindings.IntoSet
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityComponent::class)
 object HomepageActionModule {
     @Provides
     @IntoSet

--- a/features/homepage-action/src/main/java/com/duchastel/simon/simplelauncher/features/homepageaction/ui/HomepageActionPresenter.kt
+++ b/features/homepage-action/src/main/java/com/duchastel/simon/simplelauncher/features/homepageaction/ui/HomepageActionPresenter.kt
@@ -30,11 +30,11 @@ class HomepageActionPresenter @Inject internal constructor(
             onClick = {
                 coroutineScope.launch {
                     // TODO - replace this with a real call to the repository
-                    delay(500.milliseconds)
-//                    val smsSent = smsRepository.sendSms(
-//                        "",
-//                        "Test 123",
-//                    )
+                    val smsSent = smsRepository.sendSms(
+                        "",
+                        "(Ignore) Test message from Simple Launcher",
+                    )
+                    println("SMS sent: $smsSent")
                 }
             }
         )

--- a/features/permissions/build.gradle.kts
+++ b/features/permissions/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    namespace = "com.duchastel.simon.simplelauncher.features.sms"
+    namespace = "com.duchastel.simon.simplelauncher.features.permissions"
     compileSdk = 35
 
     defaultConfig {
@@ -27,8 +27,6 @@ android {
 }
 
 dependencies {
-    implementation(project(":features:permissions"))
-
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.hilt.android)

--- a/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/data/Permission.kt
+++ b/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/data/Permission.kt
@@ -1,0 +1,5 @@
+package com.duchastel.simon.simplelauncher.features.permissions.data
+
+enum class Permission {
+    SEND_SMS
+}

--- a/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/data/PermissionsRepository.kt
+++ b/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/data/PermissionsRepository.kt
@@ -1,0 +1,16 @@
+package com.duchastel.simon.simplelauncher.features.permissions.data
+
+/**
+ * Manages requesting permissions from the user.
+ */
+interface PermissionsRepository {
+    /**
+     * Requests the given [permission] from the user. Suspends until the permission is either
+     * granted or denied. Note that this might not result in a prompt to the user, such as if the
+     * permission is already granted.
+     *
+     * @param permission the permission to be requested
+     * @return true if the permission was granted, false otherwise
+     */
+    suspend fun requestPermission(permission: Permission): Boolean
+}

--- a/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/data/PermissionsRepositoryImpl.kt
+++ b/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/data/PermissionsRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package com.duchastel.simon.simplelauncher.features.permissions.data
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.activity.ComponentActivity
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+class PermissionsRepositoryImpl @Inject internal constructor(
+    private val activity: Activity,
+) : PermissionsRepository {
+
+    private val permissionsFlow: MutableStateFlow<Map<Permission, Boolean>> = MutableStateFlow(mapOf())
+
+    /**
+     * [activity] is required to be a [ComponentActivity]. Throw if it isn't.
+     */
+    private val requestPermissionLauncher =
+        (activity as ComponentActivity).registerForActivityResult(
+            ActivityResultContracts.RequestMultiplePermissions()
+        ) { isGranted: Map<String, Boolean> ->
+            permissionsFlow.update { currentPermissions ->
+                currentPermissions.toMutableMap().apply {
+                    isGranted.forEach { (permission, isGranted) ->
+                        val typedPermission = permission.asPermission()
+                        if (typedPermission != null) {
+                            put(typedPermission, isGranted)
+                        }
+                    }
+                }
+            }
+        }
+
+    override suspend fun requestPermission(permission: Permission): Boolean {
+        val permissionStatus = ContextCompat.checkSelfPermission(
+            activity, // context
+            permission.asManifestPermission() // permission
+        )
+        if (permissionStatus == PackageManager.PERMISSION_GRANTED) {
+            permissionsFlow.update { currentPermissions ->
+                currentPermissions + (permission to true)
+            }
+            return true
+        } else {
+            requestPermissionLauncher.launch(arrayOf(permission.asManifestPermission()))
+            return permissionsFlow.drop(1).first()[permission] == true
+        }
+    }
+
+    private fun Permission.asManifestPermission(): String =
+        when (this) {
+            Permission.SEND_SMS -> android.Manifest.permission.SEND_SMS
+        }
+
+    private fun String.asPermission(): Permission? =
+        when (this) {
+            android.Manifest.permission.SEND_SMS -> Permission.SEND_SMS
+            else -> null
+        }
+}

--- a/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/di/PermissionsModule.kt
+++ b/features/permissions/src/main/java/com/duchastel/simon/simplelauncher/features/permissions/di/PermissionsModule.kt
@@ -1,0 +1,16 @@
+package com.duchastel.simon.simplelauncher.features.permissions.di
+
+import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepository
+import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+
+@Module
+@InstallIn(ActivityComponent::class)
+abstract class PermissionsModule {
+
+    @Binds
+    abstract fun bindPermissionsRepository(impl: PermissionsRepositoryImpl): PermissionsRepository
+}

--- a/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepository.kt
+++ b/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepository.kt
@@ -1,12 +1,16 @@
 package com.duchastel.simon.simplelauncher.features.sms.data
 
 /**
- *
+ * Repository for sending, receiving, and managing SMS messages.
  */
 interface SmsRepository {
 
     /**
+     * Sends an SMS message to the specified phone number. Returns true if the message was sent
+     * successfully, false otherwise.
      *
+     * @param phoneNumber The recipient's phone number in international or local format.
+     * @param message The content of the SMS to be sent.
      */
-    suspend fun sendSms(phoneNumber: String, message: String)
+    suspend fun sendSms(phoneNumber: String, message: String): Boolean
 }

--- a/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImpl.kt
+++ b/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImpl.kt
@@ -2,24 +2,29 @@ package com.duchastel.simon.simplelauncher.features.sms.data
 
 import android.content.Context
 import android.telephony.SmsManager
+import com.duchastel.simon.simplelauncher.features.permissions.data.Permission
+import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class SmsRepositoryImpl @Inject internal constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val permissionRepository: PermissionsRepository,
 ): SmsRepository {
 
     private val smsManager: SmsManager = context.getSystemService(SmsManager::class.java)
 
-    override suspend fun sendSms(phoneNumber: String, message: String) {
-        smsManager.sendTextMessage(
-            phoneNumber, // destinationAddress
-            null,        // scAddress
-            message,     // text
-            null,        // sentIntent
-            null,        // deliveryIntent
-        )
+    override suspend fun sendSms(phoneNumber: String, message: String): Boolean {
+        val result: Boolean = permissionRepository.requestPermission(Permission.SEND_SMS)
 
-        // TODO - wait for successful sent intent via activity result callback (wrap in suspend fun)
+//        smsManager.sendTextMessage(
+//            phoneNumber, // destinationAddress
+//            null,        // scAddress
+//            message,     // text
+//            null,        // sentIntent
+//            null,        // deliveryIntent
+//        )
+
+        return result
     }
 }

--- a/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/di/SmsModule.kt
+++ b/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/di/SmsModule.kt
@@ -5,10 +5,10 @@ import com.duchastel.simon.simplelauncher.features.sms.data.SmsRepositoryImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import dagger.hilt.android.components.ActivityComponent
 
 @Module
-@InstallIn(SingletonComponent::class)
+@InstallIn(ActivityComponent::class)
 abstract class SmsModule {
     @Binds
     abstract fun bindSmsRepository(smsRepositoryImpl: SmsRepositoryImpl): SmsRepository

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,4 +25,5 @@ include(":ui")
 include(":features:app-list")
 include(":features:homepage-action")
 include(":features:sms")
+include(":features:permissions")
  


### PR DESCRIPTION
For sending SMS messages in the homepage action (#6), I need SMS permissions from the user. This PR adds a `permissions` module to encapsulate this behavior