### PR TITLE
feat: Add telelphony check to send sms

### DIFF
--- a/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImpl.kt
+++ b/features/sms/src/main/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.duchastel.simon.simplelauncher.features.sms.data
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.telephony.SmsManager
 import com.duchastel.simon.simplelauncher.features.permissions.data.Permission
 import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepository
@@ -13,9 +14,17 @@ class SmsRepositoryImpl @Inject internal constructor(
 ): SmsRepository {
 
     private val smsManager: SmsManager = context.getSystemService(SmsManager::class.java)
+    private val packageManager = context.packageManager
 
     override suspend fun sendSms(phoneNumber: String, message: String): Boolean {
         val result: Boolean = permissionRepository.requestPermission(Permission.SEND_SMS)
+        if (!result) {
+            return false
+        }
+
+        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
+            return false
+        }
 
 //        smsManager.sendTextMessage(
 //            phoneNumber, // destinationAddress

--- a/features/sms/src/test/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImplTest.kt
+++ b/features/sms/src/test/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImplTest.kt
@@ -1,36 +1,58 @@
 package com.duchastel.simon.simplelauncher.features.sms.data
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.telephony.SmsManager
 import com.duchastel.simon.simplelauncher.features.permissions.data.Permission
 import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.mockito.kotlin.any
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SmsRepositoryImplTest {
     private lateinit var context: Context
     private lateinit var permissionRepository: PermissionsRepository
+    private lateinit var packageManager: PackageManager
+    private lateinit var smsManager: SmsManager
+
     private lateinit var smsRepository: SmsRepositoryImpl
 
     @Before
     fun setUp() {
-        context = mock()
-        permissionRepository = mock()
-        whenever(context.getSystemService(SmsManager::class.java)).thenReturn(mock())
+        smsManager = mock()
+        permissionRepository = mock {
+            onBlocking { requestPermission(Permission.SEND_SMS) } doReturn true
+        }
+        packageManager = mock {
+            on { hasSystemFeature(PackageManager.FEATURE_TELEPHONY) } doReturn true
+        }
+        context = mock {
+            on { packageManager } doReturn packageManager
+            on { getSystemService(SmsManager::class.java) } doReturn smsManager
+        }
+
         smsRepository = SmsRepositoryImpl(context, permissionRepository)
     }
 
     @Test
     fun `sendSms returns false when permission denied`() = runTest {
         whenever(permissionRepository.requestPermission(Permission.SEND_SMS)).thenReturn(false)
+
+        val result = smsRepository.sendSms("1234567890", "dummy message")
+        assertFalse(result)
+    }
+
+    @Test
+    fun `sendSms returns false when no telephony feature`() = runTest {
+        whenever(packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY))
+            .thenReturn(false)
+
         val result = smsRepository.sendSms("1234567890", "dummy message")
         assertFalse(result)
     }


### PR DESCRIPTION
When sending an SMS, we need to first check if the user's device has the telephony feature (ie. can it send text messages at all)