### PR TITLE
feat: Add a sliding drawer composable for the app list

### DIFF
--- a/app/src/main/java/com/duchastel/simon/simplelauncher/MainActivity.kt
+++ b/app/src/main/java/com/duchastel/simon/simplelauncher/MainActivity.kt
@@ -1,26 +1,19 @@
 package com.duchastel.simon.simplelauncher
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.pager.VerticalPager
-import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.lifecycleScope
 import com.duchastel.simon.simplelauncher.features.applist.ui.AppListScreen
-import com.duchastel.simon.simplelauncher.features.permissions.data.Permission
-import com.duchastel.simon.simplelauncher.features.permissions.data.PermissionsRepository
+import com.duchastel.simon.simplelauncher.ui.components.VerticalSlidingDrawer
 import com.duchastel.simon.simplelauncher.ui.theme.SimpleLauncherTheme
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.CircuitContent
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -39,16 +32,10 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize(),
                         color = MaterialTheme.colorScheme.background
                     ) {
-                        val pagerState = rememberPagerState(pageCount = { 2 })
-                        VerticalPager(
-                            state = pagerState,
-                            modifier = Modifier
-                        ) { page ->
-                            when (page) {
-                                0 -> Homepage()
-                                1 -> CircuitContent(AppListScreen())
-                            }
-                        }
+                        VerticalSlidingDrawer(
+                            content = { Homepage() },
+                            drawerContent = { CircuitContent(AppListScreen) }
+                        )
                     }
                 }
             }

--- a/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppListPresenter.kt
+++ b/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppListPresenter.kt
@@ -18,7 +18,7 @@ import javax.inject.Inject
  * Screen for displaying the list of installed applications.
  */
 @Parcelize
-class AppListScreen : Screen, Parcelable
+data object AppListScreen : Screen, Parcelable
 
 data class AppListState(
     /**

--- a/ui/src/main/java/com/duchastel/simon/simplelauncher/ui/components/VerticalSlidingDrawer.kt
+++ b/ui/src/main/java/com/duchastel/simon/simplelauncher/ui/components/VerticalSlidingDrawer.kt
@@ -1,0 +1,65 @@
+package com.duchastel.simon.simplelauncher.ui.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+@Composable
+fun VerticalSlidingDrawer(
+    content: @Composable () -> Unit,
+    drawerContent: @Composable () -> Unit
+) {
+    var drawerOffset by remember { mutableFloatStateOf(0f) }
+    val animatedDrawerOffset by animateFloatAsState(
+        targetValue = drawerOffset,
+        animationSpec = tween(durationMillis = 300), label = "drawerOffsetAnimation"
+    )
+
+    val drawerHeightPx = with(LocalDensity.current) { 200.dp.toPx() }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        content()
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .offset { IntOffset(x = 0, y = animatedDrawerOffset.roundToInt()) }
+                .draggable(
+                    orientation = Orientation.Vertical,
+                    state = rememberDraggableState { delta ->
+                        val newOffset = animatedDrawerOffset + delta
+                        drawerOffset = newOffset.coerceIn(-drawerHeightPx, 0f)
+                    },
+                    onDragStopped = { velocity ->
+                        if (velocity < 0 && animatedDrawerOffset < -drawerHeightPx / 2) {
+                            drawerOffset = -drawerHeightPx
+                        } else if (velocity > 0 && animatedDrawerOffset > -drawerHeightPx / 2) {
+                            drawerOffset = 0f
+                        } else if (animatedDrawerOffset < -drawerHeightPx / 2) {
+                            drawerOffset = -drawerHeightPx
+                        } else {
+                            drawerOffset = 0f
+                        }
+                    }
+                )
+        ) {
+            drawerContent()
+        }
+    }
+}


### PR DESCRIPTION
_Work in progress_ This PR adds a composable to replace the VerticalPager with a sliding drawer for the app list. When the user slides up the app list will come up, and they can slide it back down too.