### PR TITLE
chore: Update gitignore with .kotlin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ google-services.json
 
 # macOS
 .DS_Store
+
+# Kotlin
+.kotlin/


### PR DESCRIPTION
Ignore all files in the `.kotlin/`, which should not be committed. They appear to be build files of some kind.