### PR TITLE
Fix annotation warnings for dependency injection parameters

### DIFF
--- a/modules/libs/intents/src/main/java/com/duchastel/simon/simplelauncher/intents/IntentLauncherImpl.kt
+++ b/modules/libs/intents/src/main/java/com/duchastel/simon/simplelauncher/intents/IntentLauncherImpl.kt
@@ -7,7 +7,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class IntentLauncherImpl @Inject constructor(
-    @ActivityContext private val context: Context,
+    @param:ActivityContext private val context: Context,
 ) : IntentLauncher {
 
     override fun startActivity(intent: Intent) {

--- a/modules/libs/sms/src/main/java/com/duchastel/simon/simplelauncher/libs/sms/data/SmsBroadcastReceiverFactoryImpl.kt
+++ b/modules/libs/sms/src/main/java/com/duchastel/simon/simplelauncher/libs/sms/data/SmsBroadcastReceiverFactoryImpl.kt
@@ -9,7 +9,7 @@ import javax.inject.Inject
 import android.app.PendingIntent
 
 class SmsBroadcastReceiverFactoryImpl @Inject internal constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : SmsBroadcastReceiverFactory {
 
     override fun createSentSmsBroadcastReceiver(

--- a/modules/libs/sms/src/main/java/com/duchastel/simon/simplelauncher/libs/sms/data/SmsRepositoryImpl.kt
+++ b/modules/libs/sms/src/main/java/com/duchastel/simon/simplelauncher/libs/sms/data/SmsRepositoryImpl.kt
@@ -15,7 +15,7 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
 class SmsRepositoryImpl @Inject internal constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val permissionRepository: PermissionsRepository,
     private val smsBroadcastReceiverFactory: SmsBroadcastReceiverFactory,
 ): SmsRepository {


### PR DESCRIPTION
## Summary
- Fixed Kotlin annotation warnings by adding explicit `@param:` annotation targets
- Applied to Dagger/Hilt dependency injection annotations in constructor parameters
- Ensures annotations apply to parameters only, not fields

## Changes Made
- `IntentLauncherImpl.kt`: Changed `@ActivityContext` to `@param:ActivityContext`
- `SmsBroadcastReceiverFactoryImpl.kt`: Changed `@ApplicationContext` to `@param:ApplicationContext`
- `SmsRepositoryImpl.kt`: Changed `@ApplicationContext` to `@param:ApplicationContext`

## Test Plan
- [x] Build completes without annotation warnings
- [x] Verified with `./gradlew assemble`

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)