### PR TITLE
chore: fix dagger compiler warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,11 @@ plugins {
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.hilt) apply false
 }
+
+subprojects {
+    plugins.withId("org.jetbrains.kotlin.kapt") {
+        configure<org.jetbrains.kotlin.gradle.plugin.KaptExtension> {
+            correctErrorTypes = true
+        }
+    }
+}

--- a/modules/features/app-list/build.gradle.kts
+++ b/modules/features/app-list/build.gradle.kts
@@ -57,7 +57,3 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.test.junit4)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
@@ -10,7 +10,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class AppRepositoryImpl @Inject internal constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val intentLauncher: IntentLauncher,
 ) : AppRepository {
 

--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppListPresenter.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppListPresenter.kt
@@ -60,7 +60,7 @@ data class AppListState(
 }
 
 class AppListPresenter @Inject internal constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val appRepository: AppRepository,
     private val intentLauncher: IntentLauncher,
 ) : Presenter<AppListState> {

--- a/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/data/AppWidgetRepositoryImpl.kt
+++ b/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/data/AppWidgetRepositoryImpl.kt
@@ -18,7 +18,7 @@ import javax.inject.Singleton
 
 @Singleton
 class AppWidgetRepositoryImpl @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val appWidgetHost: LauncherAppWidgetHost,
     private val appWidgetManager: AppWidgetManager
 ) : AppWidgetRepository {

--- a/modules/features/homepage-action/build.gradle.kts
+++ b/modules/features/homepage-action/build.gradle.kts
@@ -57,7 +57,3 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.test.junit4)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/features/homepage/build.gradle.kts
+++ b/modules/features/homepage/build.gradle.kts
@@ -56,8 +56,3 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.test.junit4)
 }
-
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -62,7 +62,3 @@ dependencies {
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.test.junit4)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingsRepositoryImpl.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingsRepositoryImpl.kt
@@ -24,7 +24,7 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 )
 
 class SettingsRepositoryImpl @Inject internal constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : SettingsRepository {
 
     override fun getSettingsFlow(setting: Setting): Flow<SettingData?>? {

--- a/modules/libs/contacts/build.gradle.kts
+++ b/modules/libs/contacts/build.gradle.kts
@@ -40,7 +40,3 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/libs/emoji/build.gradle.kts
+++ b/modules/libs/emoji/build.gradle.kts
@@ -37,7 +37,3 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/libs/intents/build.gradle.kts
+++ b/modules/libs/intents/build.gradle.kts
@@ -40,7 +40,3 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/libs/permissions/build.gradle.kts
+++ b/modules/libs/permissions/build.gradle.kts
@@ -40,7 +40,3 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/libs/phone-number/build.gradle.kts
+++ b/modules/libs/phone-number/build.gradle.kts
@@ -37,7 +37,3 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
-
-kapt {
-    correctErrorTypes = true
-}

--- a/modules/libs/sms/build.gradle.kts
+++ b/modules/libs/sms/build.gradle.kts
@@ -42,7 +42,3 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
-
-kapt {
-    correctErrorTypes = true
-}


### PR DESCRIPTION
Fixes #49.  Fixes Dagger/Hilt compiler warnings due to unrecognized processor options warnings.
