### PR TITLE
Filter out all launcher apps from app list

### DIFF
--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
@@ -17,18 +17,27 @@ class AppRepositoryImpl @Inject internal constructor(
     private val packageManager: PackageManager = context.packageManager
 
     override fun getInstalledApps(): List<App> {
-        val intent = Intent(Intent.ACTION_MAIN).apply {
+        val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_LAUNCHER)
         }
 
-        val activities = packageManager.queryIntentActivities(intent, 0)
-        return activities.map { resolveInfo ->
-            App(
-                label = resolveInfo.loadLabel(packageManager).toString(),
-                packageName = resolveInfo.activityInfo.packageName,
-                icon = resolveInfo.loadIcon(packageManager)
-            )
-        }.sortedBy { it.label }
+        val homeIntent = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_HOME)
+        }
+
+        val launcherApps = packageManager.queryIntentActivities(launcherIntent, 0)
+        val homeApps = packageManager.queryIntentActivities(homeIntent, 0)
+        val homePackageNames = homeApps.map { it.activityInfo.packageName }.toSet()
+
+        return launcherApps
+            .filter { it.activityInfo.packageName !in homePackageNames }
+            .map { resolveInfo ->
+                App(
+                    label = resolveInfo.loadLabel(packageManager).toString(),
+                    packageName = resolveInfo.activityInfo.packageName,
+                    icon = resolveInfo.loadIcon(packageManager)
+                )
+            }.sortedBy { it.label }
     }
 
     override fun launchApp(app: App): Boolean {

--- a/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
+++ b/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
@@ -18,7 +18,6 @@ import android.net.Uri
 import android.provider.Settings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.verify
 
@@ -59,12 +58,50 @@ class AppRepositoryImplTest {
         }
         resolveInfo2.activityInfo = activityInfo2
 
-        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(listOf(resolveInfo1, resolveInfo2))
+        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
+            listOf(resolveInfo1, resolveInfo2), // first call: CATEGORY_LAUNCHER
+            emptyList(),                        // second call: CATEGORY_HOME (no launchers)
+        )
 
         val result = appRepository.getInstalledApps()
         assertEquals(2, result.size)
         assertEquals("A App", result[0].label)
         assertEquals("B App", result[1].label)
+    }
+
+    @Test
+    fun `getInstalledApps filters out all launchers including self`() {
+        val regularAppIcon = mock<Drawable>()
+        val selfIcon = mock<Drawable>()
+        val otherLauncherIcon = mock<Drawable>()
+
+        val regularAppInfo = ActivityInfo().apply { packageName = "com.example.regular" }
+        val selfInfo = ActivityInfo().apply { packageName = "com.duchastel.simon.simplelauncher" }
+        val otherLauncherInfo = ActivityInfo().apply { packageName = "com.other.launcher" }
+
+        val regularResolveInfo = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "Regular App"
+            override fun loadIcon(pm: PackageManager): Drawable = regularAppIcon
+        }.apply { activityInfo = regularAppInfo }
+
+        val selfResolveInfo = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "SimpleLauncher"
+            override fun loadIcon(pm: PackageManager): Drawable = selfIcon
+        }.apply { activityInfo = selfInfo }
+
+        val otherLauncherResolveInfo = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "Other Launcher"
+            override fun loadIcon(pm: PackageManager): Drawable = otherLauncherIcon
+        }.apply { activityInfo = otherLauncherInfo }
+
+        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
+            listOf(regularResolveInfo, selfResolveInfo, otherLauncherResolveInfo), // first call: CATEGORY_LAUNCHER
+            listOf(selfResolveInfo, otherLauncherResolveInfo),                     // second call: CATEGORY_HOME
+        )
+
+        val result = appRepository.getInstalledApps()
+        assertEquals(1, result.size)
+        assertEquals("Regular App", result[0].label)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Filters out all launcher apps (apps with `CATEGORY_HOME`) from the app list, preventing SimpleLauncher and any other installed launchers from appearing in the app drawer.

## Changes

- Query apps with `Intent.CATEGORY_HOME` in addition to `CATEGORY_LAUNCHER`
- Exclude any package that implements a home screen from the displayed app list
- Added tests covering filtering of self and third-party launchers

## Rationale

This is standard launcher behavior — you can't meaningfully launch another launcher from within a launcher, and it keeps the app list clean. Filtering all launchers is more robust than just filtering our own package, since users may have multiple launchers installed (Nova, Niagara, etc.).