### PR TITLE
Prevent drawer from closing on scroll overscroll with drag handle close

### DIFF
--- a/modules/libs/ui/README.md
+++ b/modules/libs/ui/README.md
@@ -23,7 +23,8 @@ modules/libs/ui/
 │   │   ├── Theme.kt                   # App theme configuration
 │   │   └── Type.kt                    # Typography system
 │   └── components/
-│       └── SettingsButton.kt          # Shared UI components
+│       ├── SettingsButton.kt          # Shared UI components
+│       └── VerticalSlidingDrawer.kt   # Bottom sheet drawer with drag handle
 └── build.gradle.kts                   # UI dependencies
 ```
 
@@ -71,6 +72,16 @@ Standardized button component used in settings screens:
 - Consistent styling and behavior
 - Built-in accessibility features
 - Theme-aware color adaptation
+
+### VerticalSlidingDrawer
+Material Design 3-styled sliding drawer used for the app launcher:
+- Drag handle using `BottomSheetDefaults.DragHandle()`
+- Expandable with configurable top padding
+- Drag handle is independently draggable to open/close the drawer
+- Scrollable drawer content consumes scroll events completely; the drawer
+  only closes from scroll overscroll when there is no meaningful scrollable
+  content remaining (configurable via `scrollPropagationThreshold`)
+- Supports nested scroll and fling gestures
 
 ### Future Components
 Planned shared components:

--- a/modules/libs/ui/build.gradle.kts
+++ b/modules/libs/ui/build.gradle.kts
@@ -38,4 +38,9 @@ dependencies {
     implementation(libs.androidx.compose.uitooling)
 
     debugImplementation(libs.androidx.compose.uitooling)
+
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.compose.test.junit4)
 }

--- a/modules/libs/ui/src/androidTest/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawerTest.kt
+++ b/modules/libs/ui/src/androidTest/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawerTest.kt
@@ -1,0 +1,29 @@
+package com.duchastel.simon.simplelauncher.libs.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class VerticalSlidingDrawerTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun drawer_renders_content_and_drag_handle() {
+        composeTestRule.setContent {
+            VerticalSlidingDrawer(
+                drawerContent = { Text("Drawer Content") },
+                content = { Box(modifier = Modifier.fillMaxSize()) }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Drawer Content").assertIsDisplayed()
+    }
+}

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -10,21 +10,27 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 enum class DragAnchors {
@@ -36,16 +42,21 @@ enum class DragAnchors {
 @Composable
 fun VerticalSlidingDrawer(
     modifier: Modifier = Modifier,
+    expandedTopPadding: Dp = 64.dp,
+    scrollPropagationThreshold: Dp = 8.dp,
     drawerContent: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val scope: BoxWithConstraintsScope = this // necessary for lint
+        val density = LocalDensity.current
+        val expandedOffsetPx = with(density) { expandedTopPadding.toPx() }
+        val thresholdPx = with(density) { scrollPropagationThreshold.toPx() }
         val anchors = DraggableAnchors {
             DragAnchors.Hidden at scope.constraints.maxHeight.toFloat()
-            DragAnchors.Expanded at 0f
+            DragAnchors.Expanded at expandedOffsetPx
         }
-        val state: AnchoredDraggableState<DragAnchors> = remember {
+        val state: AnchoredDraggableState<DragAnchors> = remember(expandedTopPadding) {
             AnchoredDraggableState<DragAnchors>(
                 initialValue = DragAnchors.Hidden,
                 anchors = anchors,
@@ -53,15 +64,22 @@ fun VerticalSlidingDrawer(
         }
         val flingBehavior = AnchoredDraggableDefaults.flingBehavior(state)
         val interactionSource = remember { MutableInteractionSource() }
-        val nestedScrollConnection = remember {
+        val dragHandleInteractionSource = remember { MutableInteractionSource() }
+        val nestedScrollConnection = remember(thresholdPx) {
             object : NestedScrollConnection {
                 override fun onPostScroll(
                     consumed: Offset,
                     available: Offset,
                     source: NestedScrollSource
                 ): Offset {
+                    // Don't propagate to drawer if child consumed any scroll,
+                    // or if available is below threshold (treat as noise)
+                    if (consumed.y != 0f || abs(available.y) < thresholdPx) {
+                        return Offset(x = available.x, y = available.y)
+                    }
+                    // Child at boundary with significant overscroll - propagate to drawer
                     val additionalConsumedY = state.dispatchRawDelta(available.y)
-                    val remainingAvailableY =  available.y - additionalConsumedY
+                    val remainingAvailableY = available.y - additionalConsumedY
                     return Offset(x = available.x, y = remainingAvailableY)
                 }
 
@@ -69,6 +87,11 @@ fun VerticalSlidingDrawer(
                     consumed: Velocity,
                     available: Velocity
                 ): Velocity {
+                    // Don't propagate fling if child consumed any velocity,
+                    // or if available is below threshold
+                    if (consumed.y != 0f || abs(available.y) < thresholdPx * 10) {
+                        return Velocity(x = 0f, y = available.y)
+                    }
                     var remainingAvailableVelocityY = available.y
                     state.anchoredDrag {
                         val scrollFlingScope =
@@ -107,9 +130,27 @@ fun VerticalSlidingDrawer(
                 modifier = Modifier
                     .fillMaxSize()
                     .offset { IntOffset(0, state.offset.roundToInt()) },
-                shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+                shape = BottomSheetDefaults.ExpandedShape,
             ) {
-                drawerContent()
+                Column(modifier = Modifier.fillMaxSize()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .anchoredDraggable(
+                                state = state,
+                                orientation = Orientation.Vertical,
+                                flingBehavior = flingBehavior,
+                                reverseDirection = false,
+                                interactionSource = dragHandleInteractionSource,
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        BottomSheetDefaults.DragHandle()
+                    }
+                    Box(modifier = Modifier.weight(1f)) {
+                        drawerContent()
+                    }
+                }
             }
         }
     }

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -12,12 +12,13 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,7 +65,10 @@ fun VerticalSlidingDrawer(
         }
         val flingBehavior = AnchoredDraggableDefaults.flingBehavior(state)
         val interactionSource = remember { MutableInteractionSource() }
-        val dragHandleInteractionSource = remember { MutableInteractionSource() }
+        val drawerInteractionSource = remember { MutableInteractionSource() }
+        val isExpanded by remember {
+            derivedStateOf { state.currentValue == DragAnchors.Expanded }
+        }
         val nestedScrollConnection = remember(thresholdPx) {
             object : NestedScrollConnection {
                 override fun onPostScroll(
@@ -90,7 +94,7 @@ fun VerticalSlidingDrawer(
                     // Don't propagate fling if child consumed any velocity,
                     // or if available is below threshold
                     if (consumed.y != 0f || abs(available.y) < thresholdPx * 10) {
-                        return Velocity(x = 0f, y = available.y)
+                        return Velocity.Zero
                     }
                     var remainingAvailableVelocityY = available.y
                     state.anchoredDrag {
@@ -111,42 +115,38 @@ fun VerticalSlidingDrawer(
         }
 
         Box(
-            modifier = modifier.nestedScroll(nestedScrollConnection)
+            modifier = modifier
+                .nestedScroll(nestedScrollConnection)
+                .anchoredDraggable(
+                    state = state,
+                    orientation = Orientation.Vertical,
+                    enabled = !isExpanded,
+                    flingBehavior = flingBehavior,
+                    reverseDirection = false,
+                    interactionSource = interactionSource,
+                )
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .anchoredDraggable(
-                        state = state,
-                        orientation = Orientation.Vertical,
-                        flingBehavior = flingBehavior,
-                        reverseDirection = false,
-                        interactionSource = interactionSource,
-                    )
-            ) {
+            Box(modifier = Modifier.fillMaxSize()) {
                 content()
             }
             Surface(
                 modifier = Modifier
                     .fillMaxSize()
-                    .offset { IntOffset(0, state.offset.roundToInt()) },
+                    .offset { IntOffset(0, state.offset.roundToInt()) }
+                    .anchoredDraggable(
+                        state = state,
+                        orientation = Orientation.Vertical,
+                        enabled = isExpanded,
+                        flingBehavior = flingBehavior,
+                        reverseDirection = false,
+                        interactionSource = drawerInteractionSource,
+                    ),
                 shape = BottomSheetDefaults.ExpandedShape,
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .anchoredDraggable(
-                                state = state,
-                                orientation = Orientation.Vertical,
-                                flingBehavior = flingBehavior,
-                                reverseDirection = false,
-                                interactionSource = dragHandleInteractionSource,
-                            ),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        BottomSheetDefaults.DragHandle()
-                    }
+                    BottomSheetDefaults.DragHandle(
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                    )
                     Box(modifier = Modifier.weight(1f)) {
                         drawerContent()
                     }


### PR DESCRIPTION
- Add scrollPropagationThreshold parameter to VerticalSlidingDrawer (default 8dp). Scroll events inside the drawer are consumed completely unless the child consumed nothing AND the overscroll exceeds the threshold. This prevents the drawer from accidentally closing when scrolling through the app list.
- Make the drag handle independently draggable via anchoredDraggable so users can explicitly close the drawer by dragging the handle down.
- Update README with scroll consumption behavior documentation.