### PR TITLE
Add fade-in animations to drawer and settings button

### DIFF
--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppList.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppList.kt
@@ -12,8 +12,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -23,6 +31,11 @@ import com.google.accompanist.drawablepainter.rememberDrawablePainter
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun AppList(state: AppListState, modifier: Modifier) {
+    var settingsVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        settingsVisible = true
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             items(state.apps) { app ->
@@ -48,11 +61,16 @@ internal fun AppList(state: AppListState, modifier: Modifier) {
                 }
             }
         }
-        SettingsButton(
-            onClick = { state.onSettingsClicked() },
+        AnimatedVisibility(
+            visible = settingsVisible,
+            enter = fadeIn(animationSpec = tween(durationMillis = 1200)),
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(32.dp)
-        )
+        ) {
+            SettingsButton(
+                onClick = { state.onSettingsClicked() },
+            )
+        }
     }
 }

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -227,11 +228,15 @@ fun VerticalSlidingDrawer(
                     }
             )
 
+            val progress = (maxHeightPx - state.offset) / (maxHeightPx - expandedOffsetPx)
+            val drawerAlpha = progress.coerceIn(0f, 1f)
+
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(sheetHeight)
                     .offset { IntOffset(0, state.offset.roundToInt()) }
+                    .alpha(drawerAlpha)
                     .anchoredDraggable(
                         state = state,
                         orientation = Orientation.Vertical,


### PR DESCRIPTION
Chained off #55.

- Drawer now fades in as it opens (alpha tied to expansion progress)
- Settings button fades in with a slow 1.2s fade rather than appearing instantly