### PR TITLE
Update bottom sheet to match Material 3 design spec

### DIFF
--- a/modules/libs/ui/README.md
+++ b/modules/libs/ui/README.md
@@ -84,8 +84,10 @@ Material3 thresholds (56dp positional, 125dp/s velocity). When the drawer is ope
 inner LazyColumn scrolls normally and pulling down at the top of the list closes the
 drawer via nestedScroll coordination.
 
-Uses BottomSheetDefaults.DragHandle(), BottomSheetDefaults.ExpandedShape, and a 64dp
-top padding so the drawer stops short of the screen edge.
+Follows the Material 3 bottom sheet spec: drag handle is centered with 22dp vertical
+padding (provided by BottomSheetDefaults.DragHandle()). On screens up to 640dp wide
+the sheet spans the full width with a 72dp top margin. On larger screens the sheet is
+constrained to a max width of 640dp, centered horizontally, with a 56dp top margin.
 
 ### Future Components
 Planned shared components:

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
@@ -55,13 +56,15 @@ enum class DragAnchors {
 @Composable
 fun VerticalSlidingDrawer(
     modifier: Modifier = Modifier,
-    expandedTopPadding: Dp = 64.dp,
     drawerContent: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val scope: BoxWithConstraintsScope = this
         val density = LocalDensity.current
+        val maxWidthDp = with(density) { scope.constraints.maxWidth.toDp() }
+        val isLargeScreen = maxWidthDp > BottomSheetDefaults.SheetMaxWidth
+        val expandedTopPadding = if (isLargeScreen) 56.dp else 72.dp
         val expandedOffsetPx = with(density) { expandedTopPadding.toPx() }
         val maxHeightPx = scope.constraints.maxHeight.toFloat()
         val anchors = DraggableAnchors {
@@ -227,27 +230,32 @@ fun VerticalSlidingDrawer(
                     }
             )
 
-            Surface(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(sheetHeight)
-                    .offset { IntOffset(0, state.offset.roundToInt()) }
-                    .anchoredDraggable(
-                        state = state,
-                        orientation = Orientation.Vertical,
-                        flingBehavior = flingBehavior,
-                        reverseDirection = false,
-                        interactionSource = interactionSource,
-                    )
-                    .nestedScroll(nestedScrollConnection),
-                shape = BottomSheetDefaults.ExpandedShape,
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.TopCenter,
             ) {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    BottomSheetDefaults.DragHandle(
-                        modifier = Modifier.align(Alignment.CenterHorizontally)
-                    )
-                    Box(modifier = Modifier.weight(1f)) {
-                        drawerContent()
+                Surface(
+                    modifier = Modifier
+                        .then(if (isLargeScreen) Modifier.width(BottomSheetDefaults.SheetMaxWidth) else Modifier.fillMaxWidth())
+                        .height(sheetHeight)
+                        .offset { IntOffset(0, state.offset.roundToInt()) }
+                        .anchoredDraggable(
+                            state = state,
+                            orientation = Orientation.Vertical,
+                            flingBehavior = flingBehavior,
+                            reverseDirection = false,
+                            interactionSource = interactionSource,
+                        )
+                        .nestedScroll(nestedScrollConnection),
+                    shape = BottomSheetDefaults.ExpandedShape,
+                ) {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        BottomSheetDefaults.DragHandle(
+                            modifier = Modifier.align(Alignment.CenterHorizontally)
+                        )
+                        Box(modifier = Modifier.weight(1f)) {
+                            drawerContent()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Updates the `VerticalSlidingDrawer` component (used by the app list) to match the Material 3 bottom sheet design spec: https://m3.material.io/components/bottom-sheets/specs

Main change is capping the drawer's width to 640dp. From the spec:
> Bottom sheets span the full window width up to 640dp.