### PR TITLE
deps: bump com.slack.circuit:circuit-foundation 0.29.1 -> 0.30.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.10.1"
-circuit = "0.29.1"
+circuit = "0.30.0"
 kotlin = "2.2.0"
 kotlinxSerialization = "1.6.3"
 coreKtx = "1.10.1"


### PR DESCRIPTION
com.slack.circuit:circuit-foundation 0.29.1 -> 0.30.0\n\nDocs: https://github.com/slackhq/circuit/releases/tag/0.30.0\nFixes predictive-back crash with resetRoot and moves ViewModelBackStackRecordLocalProvider into circuit-foundation.