### PR TITLE
deps: bump Kotlin 2.2.0 -> 2.2.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "8.10.1"
 circuit = "0.29.1"
-kotlin = "2.2.0"
+kotlin = "2.2.20"
 kotlinxSerialization = "1.6.3"
 coreKtx = "1.10.1"
 junit = "4.13.2"


### PR DESCRIPTION
Kotlin 2.2.0 -> 2.2.20

Docs: https://github.com/JetBrains/kotlin/releases/tag/v2.2.20

Tooling release with bug fixes and performance improvements