### PR TITLE
deps: bump kotlinx.serialization 1.6.3 -> 1.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.10.1"
 circuit = "0.29.1"
 kotlin = "2.2.0"
-kotlinxSerialization = "1.6.3"
+kotlinxSerialization = "1.9.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"


### PR DESCRIPTION
org.jetbrains.kotlinx:kotlinx-serialization-json 1.6.3 -> 1.9.0

Docs: https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.9.0
Stabilizes JSON APIs (decodeEnumsCaseInsensitive, allowTrailingComma, prettyPrintIndent). Adds @JsonIgnoreUnknownKeys.