### PR TITLE
revert: undo unintended compileSdk 36 bump from previous PR (#62)

### DIFF
--- a/modules/app/build.gradle.kts
+++ b/modules/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.duchastel.simon.simplelauncher"

--- a/modules/features/app-list/build.gradle.kts
+++ b/modules/features/app-list/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.features.applist"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/features/app-widgets/build.gradle.kts
+++ b/modules/features/app-widgets/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.features.appwidgets"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/features/homepage-action/build.gradle.kts
+++ b/modules/features/homepage-action/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.features.homepageaction"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/features/homepage/build.gradle.kts
+++ b/modules/features/homepage/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.features.homepage"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.features.settings"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/contacts/build.gradle.kts
+++ b/modules/libs/contacts/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.contacts"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/core-ext/build.gradle.kts
+++ b/modules/libs/core-ext/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.coreext"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/emoji/build.gradle.kts
+++ b/modules/libs/emoji/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.emoji"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/intents/build.gradle.kts
+++ b/modules/libs/intents/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.intents"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/permissions/build.gradle.kts
+++ b/modules/libs/permissions/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.permissions"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/phone-number/build.gradle.kts
+++ b/modules/libs/phone-number/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.phonenumber"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/sms/build.gradle.kts
+++ b/modules/libs/sms/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.sms"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26

--- a/modules/libs/ui/build.gradle.kts
+++ b/modules/libs/ui/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 android {
     namespace = "com.duchastel.simon.simplelauncher.libs.ui"
-    compileSdk = 36
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 26


### PR DESCRIPTION
This PR reverts the `compileSdk` bump from 35 → 36 that was included in #62 (deps/activity-compose-1.13.0).

The activity-compose 1.13.0 dependency bump itself is kept; only the SDK 36 changes are rolled back so they can be reviewed and merged separately.

The compileSdk 36 bump is left to #74.