### PR TITLE
Sort app list case-insensitively

### DIFF
--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/App.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/App.kt
@@ -24,4 +24,32 @@ data class App(
      * The drawable icon displayed in the launcher UI for this app.
      */
     val icon: Drawable
-)
+) {
+
+    /**
+     * Returns a normalized key used to sort apps alphabetically.
+     *
+     * Case is ignored so that e.g. "mTicket", "luckin coffee" and "Zoom" sort together by letter
+     * instead of by ASCII code (where uppercase letters would otherwise come before lowercase ones).
+     *
+     * Leading non-letter characters are stripped so that labels like "*My App" sort under "M".
+     * Labels that contain no letters at all (e.g. "*&^") are sorted after every lettered app,
+     * keeping symbol-only apps grouped deterministically at the end.
+     */
+    fun sortKey(): String {
+        val trimmed = label.trimStart()
+        if (trimmed.isEmpty()) return SYMBOLS_AFTER_LETTERS + label.lowercase()
+        val firstLetter = trimmed.indexOfFirst { it.isLetter() }
+        return if (firstLetter == -1) {
+            SYMBOLS_AFTER_LETTERS + label.lowercase()
+        } else {
+            LETTERS_FIRST + trimmed.substring(firstLetter).lowercase()
+        }
+    }
+
+    private companion object {
+        // Sort prefixes that guarantee lettered apps come before symbol-only apps, regardless of label content.
+        private const val LETTERS_FIRST = '0'
+        private const val SYMBOLS_AFTER_LETTERS = '1'
+    }
+}

--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/App.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/App.kt
@@ -27,29 +27,7 @@ data class App(
 ) {
 
     /**
-     * Returns a normalized key used to sort apps alphabetically.
-     *
-     * Case is ignored so that e.g. "mTicket", "luckin coffee" and "Zoom" sort together by letter
-     * instead of by ASCII code (where uppercase letters would otherwise come before lowercase ones).
-     *
-     * Leading non-letter characters are stripped so that labels like "*My App" sort under "M".
-     * Labels that contain no letters at all (e.g. "*&^") are sorted after every lettered app,
-     * keeping symbol-only apps grouped deterministically at the end.
+     * Case-insensitive key used to sort apps alphabetically.
      */
-    fun sortKey(): String {
-        val trimmed = label.trimStart()
-        if (trimmed.isEmpty()) return SYMBOLS_AFTER_LETTERS + label.lowercase()
-        val firstLetter = trimmed.indexOfFirst { it.isLetter() }
-        return if (firstLetter == -1) {
-            SYMBOLS_AFTER_LETTERS + label.lowercase()
-        } else {
-            LETTERS_FIRST + trimmed.substring(firstLetter).lowercase()
-        }
-    }
-
-    private companion object {
-        // Sort prefixes that guarantee lettered apps come before symbol-only apps, regardless of label content.
-        private const val LETTERS_FIRST = '0'
-        private const val SYMBOLS_AFTER_LETTERS = '1'
-    }
+    fun sortKey(): String = label.lowercase()
 }

--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/App.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/App.kt
@@ -24,10 +24,4 @@ data class App(
      * The drawable icon displayed in the launcher UI for this app.
      */
     val icon: Drawable
-) {
-
-    /**
-     * Case-insensitive key used to sort apps alphabetically.
-     */
-    fun sortKey(): String = label.lowercase()
-}
+)

--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
@@ -37,7 +37,7 @@ class AppRepositoryImpl @Inject internal constructor(
                     packageName = resolveInfo.activityInfo.packageName,
                     icon = resolveInfo.loadIcon(packageManager)
                 )
-            }.sortedBy { it.label }
+            }.sortedBy { it.sortKey() }
     }
 
     override fun launchApp(app: App): Boolean {

--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
@@ -37,7 +37,7 @@ class AppRepositoryImpl @Inject internal constructor(
                     packageName = resolveInfo.activityInfo.packageName,
                     icon = resolveInfo.loadIcon(packageManager)
                 )
-            }.sortedBy { it.sortKey() }
+            }.sortedBy { it.label.lowercase() }
     }
 
     override fun launchApp(app: App): Boolean {

--- a/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
+++ b/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
@@ -131,32 +131,6 @@ class AppRepositoryImplTest {
     }
 
     @Test
-    fun `getInstalledApps sorts symbol-only labels after lettered ones and ignores leading symbols`() {
-        val symbols = object : ResolveInfo() {
-            override fun loadLabel(pm: PackageManager): CharSequence = "*&^"
-            override fun loadIcon(pm: PackageManager): Drawable = mock()
-        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.symbols" } }
-
-        val leadingSymbol = object : ResolveInfo() {
-            override fun loadLabel(pm: PackageManager): CharSequence = "*My App"
-            override fun loadIcon(pm: PackageManager): Drawable = mock()
-        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.myapp" } }
-
-        val apple = object : ResolveInfo() {
-            override fun loadLabel(pm: PackageManager): CharSequence = "Apple"
-            override fun loadIcon(pm: PackageManager): Drawable = mock()
-        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.apple" } }
-
-        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
-            listOf(symbols, leadingSymbol, apple), // first call: CATEGORY_LAUNCHER
-            emptyList(),                          // second call: CATEGORY_HOME
-        )
-
-        val result = appRepository.getInstalledApps()
-        assertEquals(listOf("Apple", "*My App", "*&^"), result.map { it.label })
-    }
-
-    @Test
     fun `launchApp starts correct intent`() {
         val app = App(label = "App1", packageName = "com.example.app1", icon = mock())
         val intent = mock<Intent>()

--- a/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
+++ b/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
@@ -106,28 +106,24 @@ class AppRepositoryImplTest {
 
     @Test
     fun `getInstalledApps sorts case-insensitively so lowercase-starting labels are not pushed to the end`() {
-        val zoom = object : ResolveInfo() {
-            override fun loadLabel(pm: PackageManager): CharSequence = "Zoom"
-            override fun loadIcon(pm: PackageManager): Drawable = mock()
-        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.zoom" } }
-
-        val luckin = object : ResolveInfo() {
-            override fun loadLabel(pm: PackageManager): CharSequence = "luckin coffee"
-            override fun loadIcon(pm: PackageManager): Drawable = mock()
-        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.luckin.client.us" } }
-
-        val mTicket = object : ResolveInfo() {
-            override fun loadLabel(pm: PackageManager): CharSequence = "mTicket"
-            override fun loadIcon(pm: PackageManager): Drawable = mock()
-        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.mticket" } }
+        val labels = listOf("Aza", "abc", "aZZ", "ZZZ", "zzz")
+        val resolveInfos = labels.mapIndexed { index, label ->
+            object : ResolveInfo() {
+                override fun loadLabel(pm: PackageManager): CharSequence = label
+                override fun loadIcon(pm: PackageManager): Drawable = mock()
+            }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.app$index" } }
+        }
 
         whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
-            listOf(zoom, luckin, mTicket), // first call: CATEGORY_LAUNCHER (given out-of-order)
-            emptyList(),                   // second call: CATEGORY_HOME
+            resolveInfos, // first call: CATEGORY_LAUNCHER
+            emptyList(),  // second call: CATEGORY_HOME
         )
 
         val result = appRepository.getInstalledApps()
-        assertEquals(listOf("luckin coffee", "mTicket", "Zoom"), result.map { it.label })
+        assertEquals(
+            listOf("abc", "Aza", "aZZ", "ZZZ", "zzz"),
+            result.map { it.label },
+        )
     }
 
     @Test

--- a/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
+++ b/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
@@ -105,6 +105,58 @@ class AppRepositoryImplTest {
     }
 
     @Test
+    fun `getInstalledApps sorts case-insensitively so lowercase-starting labels are not pushed to the end`() {
+        val zoom = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "Zoom"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.zoom" } }
+
+        val luckin = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "luckin coffee"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.luckin.client.us" } }
+
+        val mTicket = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "mTicket"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.mticket" } }
+
+        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
+            listOf(zoom, luckin, mTicket), // first call: CATEGORY_LAUNCHER (given out-of-order)
+            emptyList(),                   // second call: CATEGORY_HOME
+        )
+
+        val result = appRepository.getInstalledApps()
+        assertEquals(listOf("luckin coffee", "mTicket", "Zoom"), result.map { it.label })
+    }
+
+    @Test
+    fun `getInstalledApps sorts symbol-only labels after lettered ones and ignores leading symbols`() {
+        val symbols = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "*&^"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.symbols" } }
+
+        val leadingSymbol = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "*My App"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.myapp" } }
+
+        val apple = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "Apple"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.apple" } }
+
+        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
+            listOf(symbols, leadingSymbol, apple), // first call: CATEGORY_LAUNCHER
+            emptyList(),                          // second call: CATEGORY_HOME
+        )
+
+        val result = appRepository.getInstalledApps()
+        assertEquals(listOf("Apple", "*My App", "*&^"), result.map { it.label })
+    }
+
+    @Test
     fun `launchApp starts correct intent`() {
         val app = App(label = "App1", packageName = "com.example.app1", icon = mock())
         val intent = mock<Intent>()


### PR DESCRIPTION
The sort function would put lowercase apps after uppercase apps, ie. "alpha" would come after "Zoom".