### PR TITLE
Remove elevation from settings button to fix shadow pop

### DIFF
--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/SettingsButton.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/SettingsButton.kt
@@ -3,6 +3,7 @@ package com.duchastel.simon.simplelauncher.libs.ui.components
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,6 +18,12 @@ fun SettingsButton(
     FloatingActionButton(
         onClick = onClick,
         modifier = modifier,
+        elevation = FloatingActionButtonDefaults.elevation(
+            defaultElevation = 0.dp,
+            pressedElevation = 0.dp,
+            focusedElevation = 0.dp,
+            hoveredElevation = 0.dp,
+        ),
     ) {
         Icon(
             imageVector = Icons.Filled.Settings,


### PR DESCRIPTION
The settings button's drop shadow was being clipped by the alpha layer applied during the drawer fade-in, causing a one-frame cutoff/pop as the drawer settled. Removing the FAB elevation lets the button fade smoothly with no shadow artifacts.

## Before


<img width="92" height="82" alt="Screenshot 2026-07-04 at 2 34 53 AM" src="https://github.com/user-attachments/assets/12e8e4df-9ff6-440b-b490-21fbab660e58" />

## After

<img width="80" height="95" alt="Screenshot 2026-07-04 at 2 42 07 AM" src="https://github.com/user-attachments/assets/7dfcb8e8-9a90-4f07-ac73-552cea8271eb" />

