### PR TITLE
Close the app drawer with the back gesture

### DIFF
--- a/modules/app/src/main/AndroidManifest.xml
+++ b/modules/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.SimpleLauncher"
+        android:enableOnBackInvokedCallback="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/modules/libs/ui/build.gradle.kts
+++ b/modules/libs/ui/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.activity.compose)
     implementation("androidx.compose.material:material-icons-core")
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.width
+import androidx.activity.compose.BackHandler
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
@@ -77,6 +79,10 @@ class VerticalSlidingDrawerState(
     val targetValue: DragAnchors
         get() = anchoredDraggableState.targetValue
 
+    suspend fun collapse() {
+        anchoredDraggableState.animateTo(DragAnchors.Hidden)
+    }
+
     val progress: Float by derivedStateOf(structuralEqualityPolicy()) {
         val offset = anchoredDraggableState.offset
         if (offset.isNaN()) {
@@ -130,6 +136,11 @@ fun VerticalSlidingDrawer(
         val flingBehavior = AnchoredDraggableDefaults.flingBehavior(drawerState)
         val interactionSource = remember { MutableInteractionSource() }
         val coroutineScope = rememberCoroutineScope()
+
+        val isExpanded by remember { derivedStateOf { state.currentValue == DragAnchors.Expanded } }
+        BackHandler(enabled = isExpanded) {
+            coroutineScope.launch { state.collapse() }
+        }
 
         val positionalThreshold = with(density) { 56.dp.toPx() }
         val velocityThreshold = with(density) { 125.dp.toPx() }


### PR DESCRIPTION
When the vertical app drawer is open, pressing the system back button or swiping back now closes it instead of finishing the launcher.

## Stack

- #81 Close the app drawer with the back gesture :point_left:
- #82 Animate the drawer with predictive back gestures