### PR TITLE
Replace deprecated onBlocking stubbing with on {}

### DIFF
--- a/modules/features/homepage-action/src/test/java/com/duchastel/simon/simplelauncher/features/homepageaction/ui/HomepageActionPresenterTest.kt
+++ b/modules/features/homepage-action/src/test/java/com/duchastel/simon/simplelauncher/features/homepageaction/ui/HomepageActionPresenterTest.kt
@@ -74,7 +74,7 @@ class HomepageActionPresenterTest {
     @Test
     fun `onLongClick calls sendSms on repository with repeated emoji`() = runTest {
         val scope = mock<LongClickScope> {
-            onBlocking { tryAwaitRelease() } doAnswer {
+            on { tryAwaitRelease() } doAnswer {
                 runBlocking {
                     delay(1500) // 3 emojis expected, since we delay 3x 500ms = 1500ms
                     true
@@ -94,7 +94,7 @@ class HomepageActionPresenterTest {
     @Test
     fun `onLongClick does not sendSms on repository when cancelled`() = runTest {
         val scope = mock<LongClickScope> {
-            onBlocking { tryAwaitRelease() }.thenReturn(false)
+            on { tryAwaitRelease() }.thenReturn(false)
         }
         whenever(smsRepository.sendSms(any(), any())).thenReturn(true)
 

--- a/modules/libs/sms/src/test/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImplTest.kt
+++ b/modules/libs/sms/src/test/java/com/duchastel/simon/simplelauncher/features/sms/data/SmsRepositoryImplTest.kt
@@ -41,7 +41,7 @@ class SmsRepositoryImplTest {
     fun setUp() {
         smsManager = mock()
         permissionRepository = mock {
-            onBlocking { requestPermission(Permission.SEND_SMS) } doReturn true
+            on { requestPermission(Permission.SEND_SMS) } doReturn true
         }
         packageManager = mock {
             on { hasSystemFeature(PackageManager.FEATURE_TELEPHONY) } doReturn true


### PR DESCRIPTION
Replaces deprecated mockito-kotlin onBlocking stubbing with the unified on {} API, removing the corresponding build warnings.