### PR TITLE
Fix app list filtering so Settings and other non-launcher apps aren't hidden

### DIFF
--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImpl.kt
@@ -9,6 +9,11 @@ import com.duchastel.simon.simplelauncher.intents.IntentLauncher
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
+private data class ComponentIdentifier(
+    val packageName: String,
+    val className: String,
+)
+
 class AppRepositoryImpl @Inject internal constructor(
     @param:ApplicationContext private val context: Context,
     private val intentLauncher: IntentLauncher,
@@ -27,10 +32,21 @@ class AppRepositoryImpl @Inject internal constructor(
 
         val launcherApps = packageManager.queryIntentActivities(launcherIntent, 0)
         val homeApps = packageManager.queryIntentActivities(homeIntent, 0)
-        val homePackageNames = homeApps.map { it.activityInfo.packageName }.toSet()
+        val homeComponentNames = homeApps.map { resolveInfo ->
+            ComponentIdentifier(
+                packageName = resolveInfo.activityInfo.packageName,
+                className = resolveInfo.activityInfo.name,
+            )
+        }.toSet()
 
         return launcherApps
-            .filter { it.activityInfo.packageName !in homePackageNames }
+            .filter { resolveInfo ->
+                val componentIdentifier = ComponentIdentifier(
+                    packageName = resolveInfo.activityInfo.packageName,
+                    className = resolveInfo.activityInfo.name,
+                )
+                componentIdentifier !in homeComponentNames
+            }
             .map { resolveInfo ->
                 App(
                     label = resolveInfo.loadLabel(packageManager).toString(),

--- a/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
+++ b/modules/features/app-list/src/test/java/com/duchastel/simon/simplelauncher/features/applist/data/AppRepositoryImplTest.kt
@@ -41,10 +41,14 @@ class AppRepositoryImplTest {
     fun `getInstalledApps returns mapped and sorted apps`() {
         val icon1 = mock<Drawable>()
         val icon2 = mock<Drawable>()
-        val activityInfo1 = ActivityInfo()
-        activityInfo1.packageName = "com.example.appb"
-        val activityInfo2 = ActivityInfo()
-        activityInfo2.packageName = "com.example.appa"
+        val activityInfo1 = ActivityInfo().apply {
+            packageName = "com.example.appb"
+            name = "com.example.appb.MainActivity"
+        }
+        val activityInfo2 = ActivityInfo().apply {
+            packageName = "com.example.appa"
+            name = "com.example.appa.MainActivity"
+        }
 
         val resolveInfo1 = object : ResolveInfo() {
             override fun loadLabel(pm: PackageManager): CharSequence = "B App"
@@ -75,9 +79,18 @@ class AppRepositoryImplTest {
         val selfIcon = mock<Drawable>()
         val otherLauncherIcon = mock<Drawable>()
 
-        val regularAppInfo = ActivityInfo().apply { packageName = "com.example.regular" }
-        val selfInfo = ActivityInfo().apply { packageName = "com.duchastel.simon.simplelauncher" }
-        val otherLauncherInfo = ActivityInfo().apply { packageName = "com.other.launcher" }
+        val regularAppInfo = ActivityInfo().apply {
+            packageName = "com.example.regular"
+            name = "com.example.regular.MainActivity"
+        }
+        val selfInfo = ActivityInfo().apply {
+            packageName = "com.duchastel.simon.simplelauncher"
+            name = "com.duchastel.simon.simplelauncher.MainActivity"
+        }
+        val otherLauncherInfo = ActivityInfo().apply {
+            packageName = "com.other.launcher"
+            name = "com.other.launcher.MainActivity"
+        }
 
         val regularResolveInfo = object : ResolveInfo() {
             override fun loadLabel(pm: PackageManager): CharSequence = "Regular App"
@@ -111,7 +124,12 @@ class AppRepositoryImplTest {
             object : ResolveInfo() {
                 override fun loadLabel(pm: PackageManager): CharSequence = label
                 override fun loadIcon(pm: PackageManager): Drawable = mock()
-            }.apply { activityInfo = ActivityInfo().apply { packageName = "com.example.app$index" } }
+            }.apply {
+                activityInfo = ActivityInfo().apply {
+                    packageName = "com.example.app$index"
+                    name = "com.example.app$index.MainActivity"
+                }
+            }
         }
 
         whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
@@ -124,6 +142,38 @@ class AppRepositoryImplTest {
             listOf("abc", "Aza", "aZZ", "ZZZ", "zzz"),
             result.map { it.label },
         )
+    }
+
+    @Test
+    fun `getInstalledApps keeps apps with a launcher activity even if the same package has a separate home activity`() {
+        val settingsIcon = mock<Drawable>()
+        val settingsLauncherInfo = ActivityInfo().apply {
+            packageName = "com.android.settings"
+            name = "com.android.settings.Settings"
+        }
+        val settingsFallbackHomeInfo = ActivityInfo().apply {
+            packageName = "com.android.settings"
+            name = "com.android.settings.FallbackHome"
+        }
+
+        val settingsResolveInfo = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "Settings"
+            override fun loadIcon(pm: PackageManager): Drawable = settingsIcon
+        }.apply { activityInfo = settingsLauncherInfo }
+
+        val fallbackHomeResolveInfo = object : ResolveInfo() {
+            override fun loadLabel(pm: PackageManager): CharSequence = "FallbackHome"
+            override fun loadIcon(pm: PackageManager): Drawable = mock()
+        }.apply { activityInfo = settingsFallbackHomeInfo }
+
+        whenever(packageManager.queryIntentActivities(any(), eq(0))).thenReturn(
+            listOf(settingsResolveInfo), // first call: CATEGORY_LAUNCHER
+            listOf(fallbackHomeResolveInfo), // second call: CATEGORY_HOME
+        )
+
+        val result = appRepository.getInstalledApps()
+        assertEquals(1, result.size)
+        assertEquals("Settings", result[0].label)
     }
 
     @Test


### PR DESCRIPTION
The app list was filtering out every package that exposed a CATEGORY_HOME activity, which incorrectly hid the system Settings app because it also declares a FallbackHome activity. Filtering is now done by component instead of by package, so only actual home activities are removed from the launcher grid.