### PR TITLE
Handle edge-to-edge in SettingsActivity

### DIFF
--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/SettingsActivity.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/SettingsActivity.kt
@@ -5,11 +5,14 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.duchastel.simon.simplelauncher.features.settings.ui.settings.SettingsScreen
 import com.duchastel.simon.simplelauncher.libs.permissions.data.PermissionsRepository
 import com.duchastel.simon.simplelauncher.libs.contacts.data.ContactsRepository
@@ -38,6 +41,8 @@ class SettingsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        enableEdgeToEdge()
+
         permissionsRepository.activityOnCreate()
         contactsRepository.activityOnCreate()
 
@@ -47,9 +52,15 @@ class SettingsActivity : ComponentActivity() {
                     Surface(
                         modifier = Modifier.fillMaxSize(),
                     ) {
-                        val backstack = rememberSaveableBackStack(SettingsScreen)
-                        val navigator = rememberCircuitNavigator(backstack)
-                        NavigableCircuitContent(navigator, backstack)
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .windowInsetsPadding(WindowInsets.systemBars)
+                        ) {
+                            val backstack = rememberSaveableBackStack(SettingsScreen)
+                            val navigator = rememberCircuitNavigator(backstack)
+                            NavigableCircuitContent(navigator, backstack)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The settings screen was drawing content under the status bar, causing the row label to overlap system UI. Enable edge-to-edge on the activity and apply system-bar window insets in Compose so content stays clear of the status and navigation bars.

## Before

<img width="362" height="108" alt="Screenshot 2026-07-04 at 11 28 34 PM" src="https://github.com/user-attachments/assets/3da46b53-ce72-4854-8025-6a34c24cd393" />

## After

<img width="365" height="200" alt="Screenshot 2026-07-04 at 11 30 30 PM" src="https://github.com/user-attachments/assets/8d8982b8-9ca5-446a-a9fd-3de700f8e857" />
