### PR TITLE
Add predictive back gesture navigation within SettingsActivity

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 
 # Circuit
 circuit-foundation = { module = "com.slack.circuit:circuit-foundation", version.ref = "circuit" }
+circuit-gesture-navigation = { module = "com.slack.circuit:circuitx-gesture-navigation", version.ref = "circuit" }
 circuit-overlay = { module = "com.slack.circuit:circuit-overlay", version.ref = "circuit" }
 circuit-runtime-presenter = { module = "com.slack.circuit:circuit-runtime-presenter", version.ref = "circuit" }
 circuit-runtime-ui = { module = "com.slack.circuit:circuit-runtime-ui", version.ref = "circuit" }

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -39,11 +39,11 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.activity.compose)
     implementation(libs.circuit.foundation)
+    implementation(libs.circuit.gesture.navigation)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.circuit.foundation)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/SettingsActivity.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/SettingsActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.duchastel.simon.simplelauncher.features.settings.ui.settings.SettingsScreen
 import com.duchastel.simon.simplelauncher.libs.permissions.data.PermissionsRepository
@@ -22,6 +23,7 @@ import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
+import com.slack.circuitx.gesturenavigation.GestureNavigationDecorationFactory
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -59,7 +61,14 @@ class SettingsActivity : ComponentActivity() {
                         ) {
                             val backstack = rememberSaveableBackStack(SettingsScreen)
                             val navigator = rememberCircuitNavigator(backstack)
-                            NavigableCircuitContent(navigator, backstack)
+                            val decorationFactory = remember(navigator) {
+                                GestureNavigationDecorationFactory(onBackInvoked = navigator::pop)
+                            }
+                            NavigableCircuitContent(
+                                navigator = navigator,
+                                backStack = backstack,
+                                decoratorFactory = decorationFactory,
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
Add the CircuitX gesture-navigation decorator to SettingsActivity so the predictive back gesture works between Circuit screens inside the settings flow (e.g. returning from a setting modification screen).