### PR TITLE
Use a non-wallpaper theme for SettingsActivity

### DIFF
--- a/modules/features/settings/src/main/AndroidManifest.xml
+++ b/modules/features/settings/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
             android:launchMode="singleTask"
             android:label="@string/title_activity_settings"
             android:exported="true"
-            android:excludeFromRecents="false" />
+            android:excludeFromRecents="false"
+            android:theme="@style/Theme.SimpleLauncher.Settings" />
     </application>
 
 </manifest>

--- a/modules/features/settings/src/main/res/values/themes.xml
+++ b/modules/features/settings/src/main/res/values/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.SimpleLauncher.Settings" parent="android:Theme.Material.NoActionBar" />
+</resources>


### PR DESCRIPTION
SettingsActivity was inheriting the launcher wallpaper theme meant for the home screen, causing the wallpaper to show through the settings window. Give it a dedicated non-wallpaper Material theme instead.