### PR TITLE
chore: Update manifest tool annotations

### DIFF
--- a/modules/app/src/main/AndroidManifest.xml
+++ b/modules/app/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />
-    <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.SEND_SMS"
+        tools:ignore="SmsAndCallLogPolicy" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
 
     <application
@@ -19,7 +20,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.SimpleLauncher"
         android:enableOnBackInvokedCallback="true"
-        tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
Suppress the SmsAndCallLogPolicy lint warning on the SEND_SMS permission and update tools:targetApi to match the current target SDK (33).