### PR TITLE
Start the homepage drawer hidden

### DIFF
--- a/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
+++ b/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
@@ -23,6 +23,7 @@ import com.duchastel.simon.simplelauncher.features.settings.data.Setting
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingData
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingsRepository
 import com.duchastel.simon.simplelauncher.intents.IntentLauncher
+import com.duchastel.simon.simplelauncher.libs.ui.components.DragAnchors
 import com.duchastel.simon.simplelauncher.libs.ui.components.SettingsButton
 import com.duchastel.simon.simplelauncher.libs.ui.components.VerticalSlidingDrawer
 import com.slack.circuit.foundation.CircuitContent
@@ -50,7 +51,7 @@ data class HomepageState(
 
 @Composable
 internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
-    val drawerState = rememberVerticalSlidingDrawerState()
+    val drawerState = rememberVerticalSlidingDrawerState(DragAnchors.Hidden)
 
     Box(modifier = modifier.fillMaxSize()) {
         VerticalSlidingDrawer(

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -71,10 +71,6 @@ class VerticalSlidingDrawerState(
     internal val anchoredDraggableState: AnchoredDraggableState<DragAnchors> =
         AnchoredDraggableState(
             initialValue = initialValue,
-            anchors = DraggableAnchors {
-                DragAnchors.Hidden at 0f
-                DragAnchors.Expanded at 0f
-            },
         )
 
     val currentValue: DragAnchors
@@ -114,8 +110,8 @@ fun rememberVerticalSlidingDrawerState(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VerticalSlidingDrawer(
-    state: VerticalSlidingDrawerState = rememberVerticalSlidingDrawerState(),
     modifier: Modifier = Modifier,
+    state: VerticalSlidingDrawerState = rememberVerticalSlidingDrawerState(),
     drawerContent: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {


### PR DESCRIPTION
The app drawer was opening on cold start because VerticalSlidingDrawerState bootstrapped AnchoredDraggableState with placeholder anchors at offset 0. When the real anchors were applied in composition, Compose snapped to Expanded regardless of the requested initial value.

Remove the placeholder anchors so the drawer initializes to the intended Hidden state, and make the homepage explicitly start Hidden so the launcher opens with a swipe up.