### PR TITLE
Remove the welcome text from the homepage

### DIFF
--- a/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
+++ b/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import com.duchastel.simon.simplelauncher.libs.ui.components.rememberVerticalSlidingDrawerState
 import androidx.compose.runtime.collectAsState
@@ -44,7 +43,6 @@ import javax.inject.Inject
 data object HomepageScreen : Screen, Parcelable
 
 data class HomepageState(
-    val text: String,
     val homepageAction: HomepageAction?,
     val onSettingsClicked: () -> Unit,
 ) : CircuitUiState {
@@ -81,10 +79,6 @@ internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
             },
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
-                Text(
-                    text = state.text,
-                    modifier = Modifier.align(Alignment.Center),
-                )
                 if (state.homepageAction != null) {
                     CircuitContent(
                         HomepageActionButton(
@@ -127,7 +121,6 @@ class HomepagePresenter @Inject internal constructor(
 
         val homepageActionSettings = settings as? SettingData.HomepageActionSettingData
         return HomepageState(
-            text = "Welcome back...",
             homepageAction = homepageActionSettings?.toUiType(),
             onSettingsClicked = {
                 val intent = SettingsActivity.newActivityIntent(context)

--- a/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
+++ b/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
@@ -27,7 +27,6 @@ class HomepagePresenterTest {
 
         presenter.test {
             val state = awaitItem()
-            assert(state.text == "Welcome back...")
             assert(state.homepageAction == null)
         }
     }
@@ -43,7 +42,6 @@ class HomepagePresenterTest {
         presenter.test {
             val state = expectMostRecentItem()
 
-            Assert.assertEquals("Welcome back...", state.text)
             Assert.assertEquals("👋", state.homepageAction?.emoji)
             Assert.assertEquals("1234567890", state.homepageAction?.smsDestination)
         }


### PR DESCRIPTION
Remove the static 'Welcome back...' text so the home screen stays minimal. The center area is left empty until a widget or other content is configured.

## Stack

- #94 Qualify LauncherAppWidgetHost Context injection with @ApplicationContext
- #93 Remove the welcome text from the homepage :point_left:
- #95 Return WidgetData from AppWidgetRepository.bindWidget
- #96 Add SettingsRepository.clearSetting
- #91 Add center widget display support to the homepage (squashed into #96)
- #97 Add center widget configuration to ModifySettingScreen