### PR TITLE
Qualify LauncherAppWidgetHost Context injection with @ApplicationContext

### DIFF
--- a/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/host/LauncherAppWidgetHost.kt
+++ b/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/host/LauncherAppWidgetHost.kt
@@ -4,12 +4,13 @@ import android.appwidget.AppWidgetHost
 import android.appwidget.AppWidgetHostView
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class LauncherAppWidgetHost @Inject constructor(
-    private val context: Context
+    @param:ApplicationContext private val context: Context
 ) : AppWidgetHost(context, HOST_ID) {
 
     companion object {


### PR DESCRIPTION
Add the missing `@ApplicationContext` qualifier to the `LauncherAppWidgetHost` constructor so Hilt can resolve the Context dependency once app-widgets is wired into the app's component graph.

## Stack

- #94 Qualify LauncherAppWidgetHost Context injection with @ApplicationContext :point_left:
- #93 Remove the welcome text from the homepage
- #95 Return WidgetData from AppWidgetRepository.bindWidget
- #96 Add SettingsRepository.clearSetting
- #91 Add center widget display support to the homepage (squashed into #96)
- #97 Add center widget configuration to ModifySettingScreen