### PR TITLE
Return WidgetData from AppWidgetRepository.bindWidget

### DIFF
--- a/modules/features/app-widgets/README.md
+++ b/modules/features/app-widgets/README.md
@@ -108,7 +108,7 @@ val availableWidgets = appWidgetRepository.getAvailableWidgets()
 
 // Bind a widget
 val widgetId = appWidgetRepository.allocateWidgetId()
-appWidgetRepository.bindWidget(widgetId, providerInfo)
+val widgetData = appWidgetRepository.bindWidget(widgetId, providerInfo).getOrThrow()
 ```
 
 ### Compose Integration

--- a/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/data/AppWidgetRepository.kt
+++ b/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/data/AppWidgetRepository.kt
@@ -22,9 +22,9 @@ interface AppWidgetRepository {
     suspend fun allocateWidgetId(): Int
     
     /**
-     * Binds a widget to the launcher
+     * Binds a widget to the launcher and returns its [WidgetData] on success.
      */
-    suspend fun bindWidget(widgetId: Int, providerInfo: WidgetProviderInfo): Result<Unit>
+    suspend fun bindWidget(widgetId: Int, providerInfo: WidgetProviderInfo): Result<WidgetData>
     
     /**
      * Removes a widget from the launcher

--- a/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/data/AppWidgetRepositoryImpl.kt
+++ b/modules/features/app-widgets/src/main/java/com/duchastel/simon/simplelauncher/features/appwidgets/data/AppWidgetRepositoryImpl.kt
@@ -54,13 +54,13 @@ class AppWidgetRepositoryImpl @Inject constructor(
         return appWidgetHost.allocateWidgetId()
     }
 
-    override suspend fun bindWidget(widgetId: Int, providerInfo: WidgetProviderInfo): Result<Unit> {
+    override suspend fun bindWidget(widgetId: Int, providerInfo: WidgetProviderInfo): Result<WidgetData> {
         return try {
             val componentName = ComponentName.unflattenFromString(providerInfo.componentName)
                 ?: return Result.failure(IllegalArgumentException("Invalid component name"))
 
             val canBind = appWidgetManager.bindAppWidgetIdIfAllowed(widgetId, componentName)
-            
+
             if (canBind) {
                 val widgetData = WidgetData(
                     widgetId = widgetId,
@@ -69,12 +69,12 @@ class AppWidgetRepositoryImpl @Inject constructor(
                     height = providerInfo.minHeight,
                     label = providerInfo.label
                 )
-                
+
                 val currentWidgets = _boundWidgets.value.toMutableList()
                 currentWidgets.add(widgetData)
                 _boundWidgets.value = currentWidgets
-                
-                Result.success(Unit)
+
+                Result.success(widgetData)
             } else {
                 // Need to request permission from user
                 Result.failure(SecurityException("Widget binding not allowed"))


### PR DESCRIPTION
Update `bindWidget` to return the bound `WidgetData` on success so callers don't duplicate widget data construction.

## Stack

- #94 Qualify LauncherAppWidgetHost Context injection with @ApplicationContext
- #93 Remove the welcome text from the homepage
- #95 Return WidgetData from AppWidgetRepository.bindWidget :point_left:
- #96 Add SettingsRepository.clearSetting
- #91 Add center widget display support to the homepage (squashed into #96)
- #97 Add center widget configuration to ModifySettingScreen