### PR TITLE
Add SettingsRepository.clearSetting

### DIFF
--- a/modules/features/homepage/README.md
+++ b/modules/features/homepage/README.md
@@ -12,6 +12,7 @@ This feature module provides the primary user interface for the launcher, displa
 - **State Management** - ViewModel and state handling
 - **Navigation** - Screen navigation and routing
 - **Dependency Injection** - Feature-specific Hilt configuration
+- **Center Widget** - Optional app widget displayed in the center of the home screen
 
 ## Architecture
 
@@ -47,6 +48,7 @@ Uses modern Android architecture:
 
 This module integrates with:
 - **App List Feature** - Consumes app data for display
+- **App Widgets Feature** - Hosts the center widget
 - **Settings Feature** - Applies user preferences
 - **Homepage Action Feature** - Handles interaction events
 - **UI Library** - Uses shared components and theming
@@ -55,7 +57,7 @@ This module integrates with:
 
 - Jetpack Compose for UI
 - Navigation Component
-- Features: `app-list`, `settings`, `homepage-action`
+- Features: `app-list`, `app-widgets`, `settings`, `homepage-action`
 - Libs: `ui`, `core-ext`
 
 ## Testing

--- a/modules/features/homepage/build.gradle.kts
+++ b/modules/features/homepage/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(project(":modules:libs:intents"))
     implementation(project(":modules:features:homepage-action"))
     implementation(project(":modules:features:app-list"))
+    implementation(project(":modules:features:app-widgets"))
     implementation(project(":modules:features:settings"))
 
     implementation(platform(libs.androidx.compose.bom))

--- a/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
+++ b/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import com.duchastel.simon.simplelauncher.libs.ui.components.rememberVerticalSlidingDrawerState
 import androidx.compose.runtime.collectAsState
@@ -21,6 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.unit.dp
 import com.duchastel.simon.simplelauncher.features.applist.ui.AppListScreen
+import com.duchastel.simon.simplelauncher.features.appwidgets.data.WidgetData
+import com.duchastel.simon.simplelauncher.features.appwidgets.ui.widget.AppWidgetScreen
 import com.duchastel.simon.simplelauncher.features.homepageaction.ui.HomepageActionButton
 import com.duchastel.simon.simplelauncher.features.settings.SettingsActivity
 import com.duchastel.simon.simplelauncher.features.settings.data.Setting
@@ -44,6 +47,7 @@ data object HomepageScreen : Screen, Parcelable
 
 data class HomepageState(
     val homepageAction: HomepageAction?,
+    val centerWidget: WidgetData?,
     val onSettingsClicked: () -> Unit,
 ) : CircuitUiState {
     data class HomepageAction(
@@ -79,6 +83,18 @@ internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
             },
         ) {
             Box(modifier = Modifier.fillMaxSize()) {
+                if (state.centerWidget != null) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .size(
+                                width = state.centerWidget.width.dp,
+                                height = state.centerWidget.height.dp,
+                            )
+                    ) {
+                        CircuitContent(AppWidgetScreen(state.centerWidget))
+                    }
+                }
                 if (state.homepageAction != null) {
                     CircuitContent(
                         HomepageActionButton(
@@ -115,13 +131,19 @@ class HomepagePresenter @Inject internal constructor(
 
     @Composable
     override fun present(): HomepageState {
-        val settings by remember {
+        val homepageSettings by remember {
             settingsRepository.getSettingsFlow(Setting.HomepageAction) ?: flowOf(null)
         }.collectAsState(null)
 
-        val homepageActionSettings = settings as? SettingData.HomepageActionSettingData
+        val centerWidgetSettings by remember {
+            settingsRepository.getSettingsFlow(Setting.CenterWidget) ?: flowOf(null)
+        }.collectAsState(null)
+
+        val homepageActionSettings = homepageSettings as? SettingData.HomepageActionSettingData
+        val centerWidgetData = (centerWidgetSettings as? SettingData.CenterWidgetSettingData)?.widgetData
         return HomepageState(
             homepageAction = homepageActionSettings?.toUiType(),
+            centerWidget = centerWidgetData,
             onSettingsClicked = {
                 val intent = SettingsActivity.newActivityIntent(context)
                 intentLauncher.startActivityAsSeparateApp(intent)

--- a/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
+++ b/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
@@ -1,6 +1,7 @@
 package com.duchastel.simon.simplelauncher.features.homepage.ui
 
 import android.content.Context
+import com.duchastel.simon.simplelauncher.features.appwidgets.data.WidgetData
 import com.duchastel.simon.simplelauncher.features.settings.data.Setting
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingData
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingsRepository
@@ -24,10 +25,12 @@ class HomepagePresenterTest {
     @Test
     fun `presenter provides default state when no homepage action setting exists`() = runTest {
         whenever(settingsRepository.getSettingsFlow(Setting.HomepageAction)).thenReturn(flowOf(null))
+        whenever(settingsRepository.getSettingsFlow(Setting.CenterWidget)).thenReturn(flowOf(null))
 
         presenter.test {
             val state = awaitItem()
             assert(state.homepageAction == null)
+            assert(state.centerWidget == null)
         }
     }
 
@@ -38,12 +41,34 @@ class HomepagePresenterTest {
             phoneNumber = "1234567890"
         )
         whenever(settingsRepository.getSettingsFlow(Setting.HomepageAction)).thenReturn(flowOf(homepageActionSetting))
+        whenever(settingsRepository.getSettingsFlow(Setting.CenterWidget)).thenReturn(flowOf(null))
 
         presenter.test {
             val state = expectMostRecentItem()
 
             Assert.assertEquals("👋", state.homepageAction?.emoji)
             Assert.assertEquals("1234567890", state.homepageAction?.smsDestination)
+            Assert.assertEquals(null, state.centerWidget)
+        }
+    }
+
+    @Test
+    fun `presenter provides state with center widget when setting exists`() = runTest {
+        val widgetData = WidgetData(
+            widgetId = 1,
+            providerComponentName = "com.example/ClockWidget",
+            width = 200,
+            height = 100,
+        )
+        val centerWidgetSetting = SettingData.CenterWidgetSettingData(widgetData)
+        whenever(settingsRepository.getSettingsFlow(Setting.HomepageAction)).thenReturn(flowOf(null))
+        whenever(settingsRepository.getSettingsFlow(Setting.CenterWidget)).thenReturn(flowOf(centerWidgetSetting))
+
+        presenter.test {
+            val state = expectMostRecentItem()
+
+            Assert.assertEquals(null, state.homepageAction)
+            Assert.assertEquals(widgetData, state.centerWidget)
         }
     }
 
@@ -55,6 +80,7 @@ class HomepagePresenterTest {
         )
         val settingsFlow = MutableStateFlow<SettingData?>(initialSetting)
         whenever(settingsRepository.getSettingsFlow(Setting.HomepageAction)).thenReturn(settingsFlow)
+        whenever(settingsRepository.getSettingsFlow(Setting.CenterWidget)).thenReturn(flowOf(null))
 
         presenter.test {
             val initialState = expectMostRecentItem()
@@ -69,6 +95,36 @@ class HomepagePresenterTest {
             val updatedState = awaitItem()
             Assert.assertEquals("🚀", updatedState.homepageAction?.emoji)
             Assert.assertEquals("0987654321", updatedState.homepageAction?.smsDestination)
+        }
+    }
+
+    @Test
+    fun `presenter updates state when center widget setting changes`() = runTest {
+        val initialWidgetData = WidgetData(
+            widgetId = 1,
+            providerComponentName = "com.example/ClockWidget",
+            width = 200,
+            height = 100,
+        )
+        val initialSetting = SettingData.CenterWidgetSettingData(initialWidgetData)
+        val settingsFlow = MutableStateFlow<SettingData?>(initialSetting)
+        whenever(settingsRepository.getSettingsFlow(Setting.HomepageAction)).thenReturn(flowOf(null))
+        whenever(settingsRepository.getSettingsFlow(Setting.CenterWidget)).thenReturn(settingsFlow)
+
+        presenter.test {
+            val initialState = expectMostRecentItem()
+            Assert.assertEquals(initialWidgetData, initialState.centerWidget)
+
+            val updatedWidgetData = WidgetData(
+                widgetId = 2,
+                providerComponentName = "com.example/WeatherWidget",
+                width = 300,
+                height = 150,
+            )
+            settingsFlow.value = SettingData.CenterWidgetSettingData(updatedWidgetData)
+
+            val updatedState = awaitItem()
+            Assert.assertEquals(updatedWidgetData, updatedState.centerWidget)
         }
     }
 }

--- a/modules/features/settings/README.md
+++ b/modules/features/settings/README.md
@@ -45,6 +45,7 @@ modules/features/settings/
 - **App Launch Settings** - Launch behavior and animations
 - **Gesture Configuration** - Custom gesture actions
 - **Search Settings** - Search behavior and indexing
+- **Center Widget** - Select an app widget to display on the home screen
 
 ### Privacy & Permissions
 - **SMS Permissions** - SMS functionality controls
@@ -70,6 +71,7 @@ Container for setting values with:
 This module integrates with:
 - **Homepage Feature** - Applies visual and behavioral settings
 - **App List Feature** - Filters and sorting preferences  
+- **App Widgets Feature** - Center widget selection and binding
 - **SMS Library** - SMS-related configuration
 - **UI Library** - Theme and styling settings
 
@@ -77,6 +79,7 @@ This module integrates with:
 
 - **DataStore** - Modern preferences storage
 - **Jetpack Compose** - Settings UI
+- Features: `app-widgets`
 - Libs: `ui`, `core-ext`
 - Hilt dependency injection
 

--- a/modules/features/settings/build.gradle.kts
+++ b/modules/features/settings/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(project(":modules:libs:contacts"))
     implementation(project(":modules:libs:phone-number"))
     implementation(project(":modules:libs:emoji"))
+    implementation(project(":modules:features:app-widgets"))
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.foundation)

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/Setting.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/Setting.kt
@@ -6,4 +6,7 @@ import kotlinx.parcelize.Parcelize
 sealed class Setting : Parcelable {
     @Parcelize
     data object HomepageAction : Setting()
+
+    @Parcelize
+    data object CenterWidget : Setting()
 }

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingData.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingData.kt
@@ -1,6 +1,8 @@
 package com.duchastel.simon.simplelauncher.features.settings.data
 
+import com.duchastel.simon.simplelauncher.features.appwidgets.data.WidgetData
 import com.duchastel.simon.simplelauncher.features.settings.data.Setting.HomepageAction
+import com.duchastel.simon.simplelauncher.features.settings.data.Setting.CenterWidget
 import kotlinx.serialization.Serializable
 
 /**
@@ -17,10 +19,19 @@ sealed interface SettingData {
         val emoji: String,
         val phoneNumber: String,
     ): SettingData
+
+    /**
+     * Data associated with the [CenterWidget] setting.
+     */
+    @Serializable
+    data class CenterWidgetSettingData(
+        val widgetData: WidgetData,
+    ): SettingData
 }
 
 fun SettingData.toSetting(): Setting {
     return when (this) {
         is SettingData.HomepageActionSettingData -> HomepageAction
+        is SettingData.CenterWidgetSettingData -> CenterWidget
     }
 }

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingsRepository.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingsRepository.kt
@@ -14,6 +14,12 @@ interface SettingsRepository {
     suspend fun saveSetting(settingData: SettingData): Boolean
 
     /**
+     * Clears any stored data for the given [setting]. Returns true when the clear was successful,
+     * false otherwise.
+     */
+    suspend fun clearSetting(setting: Setting): Boolean
+
+    /**
      * Gets the data for the current, or null if there was an error. SettingData can also be null
      * if we could read the settings successfully but no settings data for that setting was stored.
      */

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingsRepositoryImpl.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/data/SettingsRepositoryImpl.kt
@@ -63,9 +63,22 @@ class SettingsRepositoryImpl @Inject internal constructor(
         }
     }
 
+    override suspend fun clearSetting(setting: Setting): Boolean {
+        try {
+            context.dataStore.edit { preferences ->
+                preferences.remove(setting.preferenceKey())
+            }
+            return true
+        } catch (_: IOException) {
+            // if we receive an error editing the file, return false
+            return false
+        }
+    }
+
     private fun Setting.preferenceKey(): Preferences.Key<String> {
         return when (this) {
-            Setting.HomepageAction -> HOMEPAGE_ACTION
+            Setting.HomepageAction -> PreferenceKeys.HOMEPAGE_ACTION
+            Setting.CenterWidget -> PreferenceKeys.CENTER_WIDGET
         }
     }
 }
@@ -130,4 +143,9 @@ private object PreferenceKeys {
      *
      */
     val HOMEPAGE_ACTION = stringPreferencesKey("homepage_action")
+
+    /**
+     *
+     */
+    val CENTER_WIDGET = stringPreferencesKey("center_widget")
 }

--- a/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/ui/modifysetting/ModifySettingPresenter.kt
+++ b/modules/features/settings/src/main/java/com/duchastel/simon/simplelauncher/features/settings/ui/modifysetting/ModifySettingPresenter.kt
@@ -123,6 +123,7 @@ class ModifySettingPresenter @AssistedInject internal constructor(
                     },
                 )
             }
+            Setting.CenterWidget -> error("CenterWidget is not configurable yet")
         }
     }
 


### PR DESCRIPTION
Add `clearSetting` to remove a stored setting value. Note: #91 (center widget display on homepage) was accidentally squashed into this branch during a merge mishap.

## Stack

- ~~#94~~ Qualify LauncherAppWidgetHost Context injection with @ApplicationContext
- ~~#93~~ Remove the welcome text from the homepage
- ~~#95~~ Return WidgetData from AppWidgetRepository.bindWidget
- #96 Add SettingsRepository.clearSetting :point_left:
- #91 Add center widget display support to the homepage (squashed into #96)
- #97 Add center widget configuration to ModifySettingScreen