### PR TITLE
Center app icons vertically in app list

### DIFF
--- a/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppList.kt
+++ b/modules/features/app-list/src/main/java/com/duchastel/simon/simplelauncher/features/applist/ui/AppList.kt
@@ -26,6 +26,7 @@ internal fun AppList(state: AppListState, modifier: Modifier) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             items(state.apps) { app ->
                 Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
                         .fillMaxWidth()
                         .combinedClickable(


### PR DESCRIPTION
App list rows were using the default top alignment, so icons sat above the vertical center of their labels. Center the icon and label vertically within each row.



| Before | After |
| --- | --- |
| <img height="180" alt="Screenshot 2026-07-15 at 1 03 10 AM" src="https://github.com/user-attachments/assets/e8f0193d-1cf8-4609-8a87-b6bfd948f646" /> | <img height="180" alt="Screenshot 2026-07-15 at 1 12 08 AM" src="https://github.com/user-attachments/assets/904ea6d9-d31d-4322-9cc3-79e814a6f349" /> |