### PR TITLE
Persist app drawer state across rotation

### DIFF
--- a/modules/libs/ui/build.gradle.kts
+++ b/modules/libs/ui/build.gradle.kts
@@ -24,6 +24,9 @@ android {
     buildFeatures {
         compose = true
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -36,4 +39,6 @@ dependencies {
     implementation(libs.androidx.compose.uitooling)
 
     debugImplementation(libs.androidx.compose.uitooling)
+
+    testImplementation(libs.junit)
 }

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,6 +67,12 @@ enum class DragAnchors {
 }
 
 @Stable
+internal val VerticalSlidingDrawerStateSaver: Saver<VerticalSlidingDrawerState, String> =
+    Saver(
+        save = { state -> state.currentValue.name },
+        restore = { name -> VerticalSlidingDrawerState(DragAnchors.valueOf(name)) },
+    )
+
 class VerticalSlidingDrawerState(
     initialValue: DragAnchors = DragAnchors.Hidden,
 ) {
@@ -103,9 +111,10 @@ class VerticalSlidingDrawerState(
 @Composable
 fun rememberVerticalSlidingDrawerState(
     initialValue: DragAnchors = DragAnchors.Hidden,
-): VerticalSlidingDrawerState = remember {
-    VerticalSlidingDrawerState(initialValue = initialValue)
-}
+): VerticalSlidingDrawerState = rememberSaveable(
+    saver = VerticalSlidingDrawerStateSaver,
+    init = { VerticalSlidingDrawerState(initialValue = initialValue) },
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/modules/libs/ui/src/test/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawerStateTest.kt
+++ b/modules/libs/ui/src/test/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawerStateTest.kt
@@ -1,0 +1,28 @@
+package com.duchastel.simon.simplelauncher.libs.ui.components
+
+import androidx.compose.runtime.saveable.SaverScope
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VerticalSlidingDrawerStateTest {
+
+    private val saverScope = SaverScope { true }
+
+    @Test
+    fun `saver restores hidden state`() {
+        val state = VerticalSlidingDrawerState(DragAnchors.Hidden)
+        val saved = VerticalSlidingDrawerStateSaver.run { saverScope.save(state) }
+        val restored = VerticalSlidingDrawerStateSaver.restore(saved!!)
+
+        assertEquals(DragAnchors.Hidden, restored?.currentValue)
+    }
+
+    @Test
+    fun `saver restores expanded state`() {
+        val state = VerticalSlidingDrawerState(DragAnchors.Expanded)
+        val saved = VerticalSlidingDrawerStateSaver.run { saverScope.save(state) }
+        val restored = VerticalSlidingDrawerStateSaver.restore(saved!!)
+
+        assertEquals(DragAnchors.Expanded, restored?.currentValue)
+    }
+}


### PR DESCRIPTION
Use `rememberSaveable` for the drawer state so the app list stays open or closed when the device is rotated.