### PR TITLE
Close app drawer on home button / home gesture

### DIFF
--- a/modules/app/src/main/java/com/duchastel/simon/simplelauncher/MainActivity.kt
+++ b/modules/app/src/main/java/com/duchastel/simon/simplelauncher/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.duchastel.simon.simplelauncher
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,6 +11,7 @@ import androidx.compose.ui.graphics.Color
 import com.duchastel.simon.simplelauncher.features.homepage.ui.HomepageScreen
 import com.duchastel.simon.simplelauncher.libs.contacts.data.ContactsRepository
 import com.duchastel.simon.simplelauncher.libs.permissions.data.PermissionsRepository
+import com.duchastel.simon.simplelauncher.libs.ui.drawer.DrawerController
 import com.duchastel.simon.simplelauncher.libs.ui.theme.SimpleLauncherTheme
 import com.slack.circuit.backstack.rememberSaveableBackStack
 import com.slack.circuit.foundation.Circuit
@@ -30,6 +32,19 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var contactsRepository: ContactsRepository
+
+    @Inject
+    lateinit var drawerController: DrawerController
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (
+            intent.action == Intent.ACTION_MAIN &&
+            intent.hasCategory(Intent.CATEGORY_HOME)
+        ) {
+            drawerController.requestClose()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
+++ b/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
@@ -26,6 +26,7 @@ import com.duchastel.simon.simplelauncher.features.appwidgets.data.WidgetData
 import com.duchastel.simon.simplelauncher.features.appwidgets.ui.widget.AppWidgetScreen
 import com.duchastel.simon.simplelauncher.features.homepageaction.ui.HomepageActionButton
 import com.duchastel.simon.simplelauncher.features.settings.SettingsActivity
+import com.duchastel.simon.simplelauncher.libs.ui.drawer.DrawerController
 import com.duchastel.simon.simplelauncher.features.settings.data.Setting
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingData
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingsRepository
@@ -38,6 +39,7 @@ import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.screen.Screen
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -49,6 +51,7 @@ data class HomepageState(
     val homepageAction: HomepageAction?,
     val centerWidget: WidgetData?,
     val onSettingsClicked: () -> Unit,
+    val drawerCloseRequests: Flow<Unit>,
 ) : CircuitUiState {
     data class HomepageAction(
         val emoji: String,
@@ -70,6 +73,12 @@ internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
                 }
                 previousTarget = targetValue
             }
+    }
+
+    LaunchedEffect(state.drawerCloseRequests, drawerState) {
+        state.drawerCloseRequests.collect {
+            drawerState.collapse()
+        }
     }
 
     Box(modifier = modifier.fillMaxSize()) {
@@ -127,6 +136,7 @@ class HomepagePresenter @Inject internal constructor(
     @param:ApplicationContext private val context: Context,
     private val settingsRepository: SettingsRepository,
     private val intentLauncher: IntentLauncher,
+    private val drawerController: DrawerController,
 ) : Presenter<HomepageState> {
 
     @Composable
@@ -148,6 +158,7 @@ class HomepagePresenter @Inject internal constructor(
                 val intent = SettingsActivity.newActivityIntent(context)
                 intentLauncher.startActivityAsSeparateApp(intent)
             },
+            drawerCloseRequests = drawerController.closeRequests,
         )
     }
 

--- a/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
+++ b/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
@@ -5,6 +5,7 @@ import com.duchastel.simon.simplelauncher.features.appwidgets.data.WidgetData
 import com.duchastel.simon.simplelauncher.features.settings.data.Setting
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingData
 import com.duchastel.simon.simplelauncher.features.settings.data.SettingsRepository
+import com.duchastel.simon.simplelauncher.libs.ui.drawer.DrawerController
 import com.duchastel.simon.simplelauncher.intents.IntentLauncher
 import com.slack.circuit.test.test
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,7 +21,12 @@ class HomepagePresenterTest {
     private val context: Context = mock()
     private val settingsRepository: SettingsRepository = mock()
     private val intentLauncher: IntentLauncher = mock()
-    private val presenter = HomepagePresenter(context, settingsRepository, intentLauncher)
+    private val drawerController: DrawerController = mock()
+    private val presenter = HomepagePresenter(context, settingsRepository, intentLauncher, drawerController)
+
+    init {
+        whenever(drawerController.closeRequests).thenReturn(flowOf(Unit))
+    }
 
     @Test
     fun `presenter provides default state when no homepage action setting exists`() = runTest {

--- a/modules/libs/ui/build.gradle.kts
+++ b/modules/libs/ui/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -37,8 +39,11 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.uitooling)
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
 
     debugImplementation(libs.androidx.compose.uitooling)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/drawer/DrawerController.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/drawer/DrawerController.kt
@@ -1,0 +1,25 @@
+package com.duchastel.simon.simplelauncher.libs.ui.drawer
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Coordinates close requests for the launcher app drawer between the activity
+ * and the Compose UI.
+ */
+interface DrawerController {
+    val closeRequests: Flow<Unit>
+    fun requestClose()
+}
+
+@Singleton
+class DrawerControllerImpl @Inject constructor() : DrawerController {
+    private val _closeRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    override val closeRequests: Flow<Unit> = _closeRequests
+
+    override fun requestClose() {
+        _closeRequests.tryEmit(Unit)
+    }
+}

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/drawer/DrawerControllerModule.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/drawer/DrawerControllerModule.kt
@@ -1,0 +1,13 @@
+package com.duchastel.simon.simplelauncher.libs.ui.drawer
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DrawerControllerModule {
+    @Binds
+    abstract fun bindDrawerController(impl: DrawerControllerImpl): DrawerController
+}

--- a/modules/libs/ui/src/test/java/com/duchastel/simon/simplelauncher/libs/ui/drawer/DrawerControllerImplTest.kt
+++ b/modules/libs/ui/src/test/java/com/duchastel/simon/simplelauncher/libs/ui/drawer/DrawerControllerImplTest.kt
@@ -1,0 +1,26 @@
+package com.duchastel.simon.simplelauncher.libs.ui.drawer
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DrawerControllerImplTest {
+
+    @Test
+    fun `requestClose emits a close request`() = runTest {
+        val controller = DrawerControllerImpl()
+        var received = false
+        val job = launch(UnconfinedTestDispatcher()) {
+            controller.closeRequests.collect { received = true }
+        }
+
+        controller.requestClose()
+
+        assertTrue(received)
+        job.cancel()
+    }
+}


### PR DESCRIPTION
Route home-intent close requests from MainActivity to the homepage so the drawer collapses when the user presses the home button or swipes home. Depends on #105 for the singleTask launch mode that makes onNewIntent fire reliably.