### PR TITLE
Close app drawer when tapping outside of it

### DIFF
--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -303,6 +303,29 @@ fun VerticalSlidingDrawer(
                                 if (drawerState.offset.isNaN()) return@awaitEachGesture
 
                                 val opening = drawerState.currentValue == DragAnchors.Hidden
+
+                                if (!opening) {
+                                    val tapSlop = viewConfiguration.touchSlop
+                                    var tapDelta = 0f
+                                    while (true) {
+                                        val event = awaitPointerEvent()
+                                        val change = event.changes.find { it.id == down.id }
+                                            ?: break
+                                        if (change.changedToUpIgnoreConsumed()) {
+                                            if (abs(tapDelta) < tapSlop) {
+                                                change.consume()
+                                                coroutineScope.launch {
+                                                    drawerState.animateTo(DragAnchors.Hidden)
+                                                }
+                                            }
+                                            break
+                                        }
+                                        tapDelta += change.positionChange().y
+                                        if (abs(tapDelta) >= tapSlop) break
+                                    }
+                                    return@awaitEachGesture
+                                }
+
                                 val slop = viewConfiguration.touchSlop
                                 val startOffset = drawerState.offset
                                 var totalDelta = 0f


### PR DESCRIPTION
Detect taps on the background area behind the open drawer and collapse the sheet.