### PR TITLE
Use singleTask launch mode for MainActivity

### DIFF
--- a/modules/app/src/main/AndroidManifest.xml
+++ b/modules/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:exported="true"
             android:theme="@style/Theme.SimpleLauncher"
             android:excludeFromRecents="true"
+            android:launchMode="singleTask"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Ensures only one MainActivity instance exists so repeated HOME intents are delivered via onNewIntent instead of creating new activity instances. This is the standard launch mode for launcher apps.