### PR TITLE
Close app drawer from side margin taps

### DIFF
--- a/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
+++ b/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
@@ -51,6 +51,7 @@ data class HomepageState(
     val homepageAction: HomepageAction?,
     val centerWidget: WidgetData?,
     val onSettingsClicked: () -> Unit,
+    val onRequestDrawerClose: () -> Unit,
     val drawerCloseRequests: Flow<Unit>,
 ) : CircuitUiState {
     data class HomepageAction(
@@ -85,6 +86,7 @@ internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
         VerticalSlidingDrawer(
             state = drawerState,
             modifier = Modifier.fillMaxSize(),
+            onDismissRequest = state.onRequestDrawerClose,
             drawerContent = {
                 Box(modifier = Modifier.fillMaxSize()) {
                     CircuitContent(AppListScreen)
@@ -158,6 +160,7 @@ class HomepagePresenter @Inject internal constructor(
                 val intent = SettingsActivity.newActivityIntent(context)
                 intentLauncher.startActivityAsSeparateApp(intent)
             },
+            onRequestDrawerClose = { drawerController.requestClose() },
             drawerCloseRequests = drawerController.closeRequests,
         )
     }

--- a/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
+++ b/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class HomepagePresenterTest {
@@ -131,6 +132,18 @@ class HomepagePresenterTest {
 
             val updatedState = awaitItem()
             Assert.assertEquals(updatedWidgetData, updatedState.centerWidget)
+        }
+    }
+
+    @Test
+    fun `presenter requests drawer close when onRequestDrawerClose is invoked`() = runTest {
+        whenever(settingsRepository.getSettingsFlow(Setting.HomepageAction)).thenReturn(flowOf(null))
+        whenever(settingsRepository.getSettingsFlow(Setting.CenterWidget)).thenReturn(flowOf(null))
+
+        presenter.test {
+            val state = expectMostRecentItem()
+            state.onRequestDrawerClose()
+            verify(drawerController).requestClose()
         }
     }
 }

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -172,6 +172,7 @@ fun rememberVerticalSlidingDrawerState(
 fun VerticalSlidingDrawer(
     modifier: Modifier = Modifier,
     state: VerticalSlidingDrawerState = rememberVerticalSlidingDrawerState(),
+    onDismissRequest: () -> Unit = {},
     drawerContent: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -314,9 +315,7 @@ fun VerticalSlidingDrawer(
                                         if (change.changedToUpIgnoreConsumed()) {
                                             if (abs(tapDelta) < tapSlop) {
                                                 change.consume()
-                                                coroutineScope.launch {
-                                                    drawerState.animateTo(DragAnchors.Hidden)
-                                                }
+                                                onDismissRequest()
                                             }
                                             break
                                         }
@@ -445,10 +444,18 @@ fun VerticalSlidingDrawer(
 
                                 var totalY = 0f
                                 var slopExceeded = false
+                                var upConsumed = false
                                 while (true) {
                                     val event = awaitPointerEvent()
                                     val change = event.changes.find { it.id == down.id } ?: break
-                                    if (change.changedToUpIgnoreConsumed()) break
+                                    if (change.changedToUpIgnoreConsumed()) {
+                                        if (abs(totalY) < slop) {
+                                            change.consume()
+                                            upConsumed = true
+                                            onDismissRequest()
+                                        }
+                                        break
+                                    }
 
                                     totalY += change.positionChange().y
                                     if (totalY < -slop) {
@@ -456,6 +463,7 @@ fun VerticalSlidingDrawer(
                                         break
                                     }
                                 }
+                                if (upConsumed) return@awaitEachGesture
                                 if (!slopExceeded) return@awaitEachGesture
 
                                 val velocityTracker = VelocityTracker()


### PR DESCRIPTION
Tap-to-dismiss from #104 only worked above the drawer, not in the side margins on large screens. Route all background taps through `DrawerController` so any tap on the home screen closes the drawer consistently, matching the home-button behavior.