### PR TITLE
Reset app list scroll position when drawer closes

### DIFF
--- a/modules/libs/ui/README.md
+++ b/modules/libs/ui/README.md
@@ -82,7 +82,7 @@ a drag, preventing the inner LazyColumn from stealing the gesture mid-drag. The 
 tracks the finger directly via dispatchRawDelta(). On release the sheet settles using
 Material3 thresholds (56dp positional, 125dp/s velocity). When the drawer is open the
 inner LazyColumn scrolls normally and pulling down at the top of the list closes the
-drawer via nestedScroll coordination.
+drawer via nestedScroll coordination. The inner scroll position resets to the top when the drawer is hidden, so reopening the drawer always starts at the first app.
 
 Follows the Material 3 bottom sheet spec: drag handle is centered with 22dp vertical
 padding (provided by BottomSheetDefaults.DragHandle()). On screens up to 640dp wide

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
@@ -44,6 +45,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,6 +65,7 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.abs
@@ -93,6 +96,20 @@ internal fun isPointerInMargin(
     val left = center - halfSheet
     val right = center + halfSheet
     return pointerX < left || pointerX > right
+}
+
+/**
+ * Resets the scroll position whenever the drawer moves to [DragAnchors.Hidden].
+ */
+internal suspend fun resetDrawerScrollOnHide(
+    currentValueFlow: Flow<DragAnchors>,
+    resetScroll: suspend () -> Unit,
+) {
+    currentValueFlow.collect { currentValue ->
+        if (currentValue == DragAnchors.Hidden) {
+            resetScroll()
+        }
+    }
 }
 
 internal fun computeDragTarget(
@@ -198,6 +215,13 @@ fun VerticalSlidingDrawer(
         val interactionSource = remember { MutableInteractionSource() }
         val coroutineScope = rememberCoroutineScope()
         val lazyListState = rememberLazyListState()
+
+        LaunchedEffect(state, lazyListState) {
+            resetDrawerScrollOnHide(
+                currentValueFlow = snapshotFlow { state.currentValue },
+                resetScroll = { lazyListState.scrollToItem(0) },
+            )
+        }
 
         val isExpanded by remember { derivedStateOf { state.currentValue == DragAnchors.Expanded } }
         PredictiveBackHandler(enabled = isExpanded) { progress ->

--- a/modules/libs/ui/src/test/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawerScrollResetTest.kt
+++ b/modules/libs/ui/src/test/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawerScrollResetTest.kt
@@ -1,0 +1,72 @@
+package com.duchastel.simon.simplelauncher.libs.ui.components
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class VerticalSlidingDrawerScrollResetTest {
+
+    @Test
+    fun `scroll reset is requested when drawer is hidden`() = runTest {
+        val currentValueFlow = MutableStateFlow(DragAnchors.Expanded)
+        val resets = mutableListOf<Unit>()
+
+        val job = launch {
+            resetDrawerScrollOnHide(currentValueFlow) { resets.add(Unit) }
+        }
+        advanceUntilIdle()
+
+        currentValueFlow.value = DragAnchors.Hidden
+        advanceUntilIdle()
+
+        job.cancel()
+
+        assertEquals(1, resets.size)
+    }
+
+    @Test
+    fun `scroll reset is not requested while drawer stays expanded`() = runTest {
+        val currentValueFlow = MutableStateFlow(DragAnchors.Expanded)
+        val resets = mutableListOf<Unit>()
+
+        val job = launch {
+            resetDrawerScrollOnHide(currentValueFlow) { resets.add(Unit) }
+        }
+        advanceUntilIdle()
+
+        currentValueFlow.value = DragAnchors.Expanded
+        advanceUntilIdle()
+        currentValueFlow.value = DragAnchors.Expanded
+        advanceUntilIdle()
+
+        job.cancel()
+
+        assertEquals(0, resets.size)
+    }
+
+    @Test
+    fun `scroll reset is requested each time drawer is hidden`() = runTest {
+        val currentValueFlow = MutableStateFlow(DragAnchors.Expanded)
+        val resets = mutableListOf<Unit>()
+
+        val job = launch {
+            resetDrawerScrollOnHide(currentValueFlow) { resets.add(Unit) }
+        }
+        advanceUntilIdle()
+
+        currentValueFlow.value = DragAnchors.Hidden
+        advanceUntilIdle()
+        currentValueFlow.value = DragAnchors.Expanded
+        advanceUntilIdle()
+        currentValueFlow.value = DragAnchors.Hidden
+        advanceUntilIdle()
+
+        job.cancel()
+
+        assertEquals(2, resets.size)
+    }
+}


### PR DESCRIPTION
Reset the app list's scroll position to the top whenever the launcher drawer is closed, so reopening it starts at the first app.