### PR TITLE
Reset app list scroll position from the homepage

### DIFF
--- a/modules/features/homepage/README.md
+++ b/modules/features/homepage/README.md
@@ -36,6 +36,7 @@ The homepage provides:
 - **Recent Apps** - Quick access to frequently used apps
 - **Customization** - Layout and theme options
 - **Gesture Support** - Touch interactions and navigation
+- **App List Scroll Reset** - The app list's scroll position resets to the top whenever the drawer is closed, so reopening it starts at the first app
 
 ## State Management
 

--- a/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
+++ b/modules/features/homepage/src/main/java/com/duchastel/simon/simplelauncher/features/homepage/ui/Homepage.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import com.duchastel.simon.simplelauncher.libs.ui.components.rememberVerticalSlidingDrawerState
 import androidx.compose.runtime.collectAsState
@@ -63,6 +65,7 @@ data class HomepageState(
 @Composable
 internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
     val drawerState = rememberVerticalSlidingDrawerState(DragAnchors.Hidden)
+    val drawerScrollState = rememberLazyListState()
     val hapticFeedback by rememberUpdatedState(LocalHapticFeedback.current)
 
     LaunchedEffect(drawerState) {
@@ -82,9 +85,17 @@ internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
         }
     }
 
+    LaunchedEffect(drawerState, drawerScrollState) {
+        resetAppListScrollOnDrawerHide(
+            currentValueFlow = snapshotFlow { drawerState.currentValue },
+            resetScroll = { drawerScrollState.scrollToItem(0) },
+        )
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
         VerticalSlidingDrawer(
             state = drawerState,
+            drawerContentScrollState = drawerScrollState,
             modifier = Modifier.fillMaxSize(),
             onDismissRequest = state.onRequestDrawerClose,
             drawerContent = {
@@ -131,6 +142,20 @@ internal fun Homepage(state: HomepageState, modifier: Modifier = Modifier) {
                 .padding(32.dp)
                 .alpha(drawerState.progress),
         )
+    }
+}
+
+/**
+ * Resets the app list scroll position whenever the drawer moves to [DragAnchors.Hidden].
+ */
+internal suspend fun resetAppListScrollOnDrawerHide(
+    currentValueFlow: Flow<DragAnchors>,
+    resetScroll: suspend () -> Unit,
+) {
+    currentValueFlow.collect { currentValue ->
+        if (currentValue == DragAnchors.Hidden) {
+            resetScroll()
+        }
     }
 }
 

--- a/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageScrollResetTest.kt
+++ b/modules/features/homepage/src/test/java/com/duchastel/simon/simplelauncher/features/homepage/ui/HomepageScrollResetTest.kt
@@ -1,0 +1,73 @@
+package com.duchastel.simon.simplelauncher.features.homepage.ui
+
+import com.duchastel.simon.simplelauncher.libs.ui.components.DragAnchors
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+class HomepageScrollResetTest {
+
+    @Test
+    fun `scroll reset is requested when drawer is hidden`() = runTest {
+        val currentValueFlow = MutableStateFlow(DragAnchors.Expanded)
+        val resets = mutableListOf<Unit>()
+
+        val job = launch {
+            resetAppListScrollOnDrawerHide(currentValueFlow) { resets.add(Unit) }
+        }
+        advanceUntilIdle()
+
+        currentValueFlow.value = DragAnchors.Hidden
+        advanceUntilIdle()
+
+        job.cancel()
+
+        assertEquals(1, resets.size)
+    }
+
+    @Test
+    fun `scroll reset is not requested while drawer stays expanded`() = runTest {
+        val currentValueFlow = MutableStateFlow(DragAnchors.Expanded)
+        val resets = mutableListOf<Unit>()
+
+        val job = launch {
+            resetAppListScrollOnDrawerHide(currentValueFlow) { resets.add(Unit) }
+        }
+        advanceUntilIdle()
+
+        currentValueFlow.value = DragAnchors.Expanded
+        advanceUntilIdle()
+        currentValueFlow.value = DragAnchors.Expanded
+        advanceUntilIdle()
+
+        job.cancel()
+
+        assertEquals(0, resets.size)
+    }
+
+    @Test
+    fun `scroll reset is requested each time drawer is hidden`() = runTest {
+        val currentValueFlow = MutableStateFlow(DragAnchors.Expanded)
+        val resets = mutableListOf<Unit>()
+
+        val job = launch {
+            resetAppListScrollOnDrawerHide(currentValueFlow) { resets.add(Unit) }
+        }
+        advanceUntilIdle()
+
+        currentValueFlow.value = DragAnchors.Hidden
+        advanceUntilIdle()
+        currentValueFlow.value = DragAnchors.Expanded
+        advanceUntilIdle()
+        currentValueFlow.value = DragAnchors.Hidden
+        advanceUntilIdle()
+
+        job.cancel()
+
+        assertEquals(2, resets.size)
+    }
+}

--- a/modules/libs/ui/README.md
+++ b/modules/libs/ui/README.md
@@ -82,7 +82,7 @@ a drag, preventing the inner LazyColumn from stealing the gesture mid-drag. The 
 tracks the finger directly via dispatchRawDelta(). On release the sheet settles using
 Material3 thresholds (56dp positional, 125dp/s velocity). When the drawer is open the
 inner LazyColumn scrolls normally and pulling down at the top of the list closes the
-drawer via nestedScroll coordination.
+drawer via nestedScroll coordination. The drawer content scroll state can be hoisted by callers via the optional `drawerContentScrollState` parameter, allowing consumers such as the home screen to observe or reset scroll position themselves.
 
 Follows the Material 3 bottom sheet spec: drag handle is centered with 22dp vertical
 padding (provided by BottomSheetDefaults.DragHandle()). On screens up to 640dp wide

--- a/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
+++ b/modules/libs/ui/src/main/java/com/duchastel/simon/simplelauncher/libs/ui/components/VerticalSlidingDrawer.kt
@@ -173,6 +173,7 @@ fun VerticalSlidingDrawer(
     modifier: Modifier = Modifier,
     state: VerticalSlidingDrawerState = rememberVerticalSlidingDrawerState(),
     onDismissRequest: () -> Unit = {},
+    drawerContentScrollState: LazyListState = rememberLazyListState(),
     drawerContent: @Composable () -> Unit,
     content: @Composable () -> Unit,
 ) {
@@ -197,7 +198,7 @@ fun VerticalSlidingDrawer(
         val flingBehavior = AnchoredDraggableDefaults.flingBehavior(drawerState)
         val interactionSource = remember { MutableInteractionSource() }
         val coroutineScope = rememberCoroutineScope()
-        val lazyListState = rememberLazyListState()
+        val lazyListState = drawerContentScrollState
 
         val isExpanded by remember { derivedStateOf { state.currentValue == DragAnchors.Expanded } }
         PredictiveBackHandler(enabled = isExpanded) { progress ->


### PR DESCRIPTION
Hoist the drawer content scroll state to the homepage so the app list reset is driven by the screen that owns the drawer, not by the generic sliding drawer component.